### PR TITLE
[#9][feature/github-oauth-login] Github Oauth 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Submodule ###
+src/main/resources/application-security.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodule"]
+	path = submodule
+	url = https://github.com/xlffm3/submodule.git

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     runtimeOnly 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok:1.18.20'

--- a/build.gradle
+++ b/build.gradle
@@ -56,3 +56,10 @@ sourceSets {
 test {
     useJUnitPlatform()
 }
+
+processResources.dependsOn('copySecurity')
+
+task copySecurity(type: Copy) {
+    from './submodule/security/application-security.yml'
+    into './src/main/resources'
+}

--- a/src/main/java/com/spring/blog/authentication/application/OAuthService.java
+++ b/src/main/java/com/spring/blog/authentication/application/OAuthService.java
@@ -1,0 +1,52 @@
+package com.spring.blog.authentication.application;
+
+import com.spring.blog.authentication.application.dto.TokenDto;
+import com.spring.blog.authentication.domain.JwtTokenProvider;
+import com.spring.blog.authentication.domain.OAuthClient;
+import com.spring.blog.authentication.domain.user.UserProfile;
+import com.spring.blog.user.domain.User;
+import com.spring.blog.user.domain.repoistory.UserRepository;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class OAuthService {
+
+    private final OAuthClient oAuthClient;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public OAuthService(
+        OAuthClient oAuthClient,
+        UserRepository userRepository,
+        JwtTokenProvider jwtTokenProvider
+    ) {
+        this.oAuthClient = oAuthClient;
+        this.userRepository = userRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public String getGithubAuthorizationUrl() {
+        return oAuthClient.getLoginUrl();
+    }
+
+    @Transactional
+    public TokenDto createToken(String code) {
+        String accessToken = oAuthClient.getAccessToken(code);
+        UserProfile userProfile = oAuthClient.getUserProfile(accessToken);
+        String userName = userProfile.getName();
+        userRepository.findByName(userName)
+            .orElseGet(registerNewUser(userProfile));
+        String jwtToken = jwtTokenProvider.createToken(userName);
+        return new TokenDto(jwtToken, userName);
+    }
+
+    private Supplier<User> registerNewUser(UserProfile userProfile) {
+        return () -> {
+            User user = new User(userProfile.getName(), userProfile.getProfileImageUrl());
+            return userRepository.save(user);
+        };
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/application/dto/TokenDto.java
+++ b/src/main/java/com/spring/blog/authentication/application/dto/TokenDto.java
@@ -1,0 +1,23 @@
+package com.spring.blog.authentication.application.dto;
+
+public class TokenDto {
+
+    private String token;
+    private String userName;
+
+    private TokenDto() {
+    }
+
+    public TokenDto(String token, String userName) {
+        this.token = token;
+        this.userName = userName;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/domain/JwtTokenProvider.java
+++ b/src/main/java/com/spring/blog/authentication/domain/JwtTokenProvider.java
@@ -1,0 +1,10 @@
+package com.spring.blog.authentication.domain;
+
+public interface JwtTokenProvider {
+
+    String createToken(String payload);
+
+    boolean validateToken(String token);
+
+    String getPayloadByKey(String token, String key);
+}

--- a/src/main/java/com/spring/blog/authentication/domain/OAuthClient.java
+++ b/src/main/java/com/spring/blog/authentication/domain/OAuthClient.java
@@ -1,0 +1,12 @@
+package com.spring.blog.authentication.domain;
+
+import com.spring.blog.authentication.domain.user.UserProfile;
+
+public interface OAuthClient {
+
+    String getLoginUrl();
+
+    String getAccessToken(String code);
+
+    UserProfile getUserProfile(String accessToken);
+}

--- a/src/main/java/com/spring/blog/authentication/domain/user/UserProfile.java
+++ b/src/main/java/com/spring/blog/authentication/domain/user/UserProfile.java
@@ -1,0 +1,23 @@
+package com.spring.blog.authentication.domain.user;
+
+public class UserProfile {
+
+    private String name;
+    private String profileImageUrl;
+
+    private UserProfile() {
+    }
+
+    public UserProfile(String name, String profileImageUrl) {
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/infrastructure/GithubOAuthClient.java
+++ b/src/main/java/com/spring/blog/authentication/infrastructure/GithubOAuthClient.java
@@ -1,0 +1,84 @@
+package com.spring.blog.authentication.infrastructure;
+
+import com.spring.blog.authentication.domain.OAuthClient;
+import com.spring.blog.authentication.domain.user.UserProfile;
+import com.spring.blog.authentication.infrastructure.dto.AccessTokenRequestDto;
+import com.spring.blog.authentication.infrastructure.dto.AccessTokenResponseDto;
+import com.spring.blog.authentication.infrastructure.dto.UserProfileResponseDto;
+import com.spring.blog.exception.platform.PlatformHttpErrorException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
+import reactor.core.publisher.Mono;
+
+@Component
+public class GithubOAuthClient implements OAuthClient {
+
+    private static final String LOGIN_URL_FORMAT =
+        "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s";
+    private static final String ACCESS_TOKEN_URL =
+        "https://github.com/login/oauth/access_token";
+    private static final String USER_PROFILE_URL = "https://api.github.com/user";
+
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUrl;
+
+    public GithubOAuthClient(
+        @Value("${security.github.client.id}") String clientId,
+        @Value("${security.github.client.secret}") String clientSecret,
+        @Value("${security.github.url.redirect}")String redirectUrl
+    ) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUrl = redirectUrl;
+    }
+
+    @Override
+    public String getLoginUrl() {
+        return String.format(LOGIN_URL_FORMAT, clientId, redirectUrl);
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        AccessTokenRequestDto accessTokenRequestDto =
+            new AccessTokenRequestDto(code, clientId, clientSecret);
+        try {
+            return WebClient.create()
+                .post()
+                .uri(ACCESS_TOKEN_URL)
+                .body(Mono.just(accessTokenRequestDto), AccessTokenRequestDto.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(AccessTokenResponseDto.class)
+                .blockOptional()
+                .orElseThrow(PlatformHttpErrorException::new)
+                .getAccessToken();
+        } catch (WebClientException webClientException) {
+            throw new PlatformHttpErrorException();
+        }
+    }
+
+    @Override
+    public UserProfile getUserProfile(String accessToken) {
+        try {
+            UserProfileResponseDto userProfileResponseDto = WebClient.create()
+                .get()
+                .uri(USER_PROFILE_URL)
+                .headers(httpHeaders -> httpHeaders.setBearerAuth(accessToken))
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(UserProfileResponseDto.class)
+                .blockOptional()
+                .orElseThrow(PlatformHttpErrorException::new);
+            return new UserProfile(
+                userProfileResponseDto.getName(),
+                userProfileResponseDto.getProfileImageUrl()
+            );
+        } catch (WebClientException webClientException) {
+            throw new PlatformHttpErrorException();
+        }
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/infrastructure/JwtTokenProviderImpl.java
+++ b/src/main/java/com/spring/blog/authentication/infrastructure/JwtTokenProviderImpl.java
@@ -1,0 +1,66 @@
+package com.spring.blog.authentication.infrastructure;
+
+import com.spring.blog.authentication.domain.JwtTokenProvider;
+import com.spring.blog.exception.authentication.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProviderImpl implements JwtTokenProvider {
+
+    private final String secretKey;
+    private final long expirationTimeInMilliSeconds;
+
+    public JwtTokenProviderImpl(
+        @Value("${security.jwt.token.secret-key}") String secretKey,
+        @Value("${security.jwt.token.expire-length}") long expirationTimeInMilliSeconds
+    ) {
+        this.secretKey = secretKey;
+        this.expirationTimeInMilliSeconds = expirationTimeInMilliSeconds;
+    }
+
+    @Override
+    public String createToken(String payload) {
+        Date now = new Date();
+        Date expirationTime = new Date(now.getTime() + expirationTimeInMilliSeconds);
+        return Jwts.builder()
+            .claim("userName", payload)
+            .setIssuedAt(now)
+            .setExpiration(expirationTime)
+            .signWith(SignatureAlgorithm.HS256, secretKey)
+            .compact();
+    }
+
+    @Override
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token);
+            return !claims.getBody()
+                .getExpiration()
+                .before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String getPayloadByKey(String token, String key) {
+        try {
+            return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody()
+                .get(key, String.class);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new InvalidTokenException();
+        }
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/infrastructure/dto/AccessTokenRequestDto.java
+++ b/src/main/java/com/spring/blog/authentication/infrastructure/dto/AccessTokenRequestDto.java
@@ -1,0 +1,35 @@
+package com.spring.blog.authentication.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AccessTokenRequestDto {
+
+    private String code;
+
+    @JsonProperty("client_id")
+    private String clientId;
+
+    @JsonProperty("client_secret")
+    private String clientSecret;
+
+    private AccessTokenRequestDto() {
+    }
+
+    public AccessTokenRequestDto(String code, String clientId, String clientSecret) {
+        this.code = code;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/infrastructure/dto/AccessTokenResponseDto.java
+++ b/src/main/java/com/spring/blog/authentication/infrastructure/dto/AccessTokenResponseDto.java
@@ -1,0 +1,36 @@
+package com.spring.blog.authentication.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AccessTokenResponseDto {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("scope")
+    private String scope;
+
+    private AccessTokenResponseDto() {
+    }
+
+    public AccessTokenResponseDto(String accessToken, String tokenType, String scope) {
+        this.accessToken = accessToken;
+        this.tokenType = tokenType;
+        this.scope = scope;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/infrastructure/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/spring/blog/authentication/infrastructure/dto/UserProfileResponseDto.java
@@ -1,0 +1,28 @@
+package com.spring.blog.authentication.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class UserProfileResponseDto {
+
+    @JsonProperty("login")
+    private String name;
+
+    @JsonProperty("avatar_url")
+    private String profileImageUrl;
+
+    private UserProfileResponseDto() {
+    }
+
+    public UserProfileResponseDto(String name, String profileImageUrl) {
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/presentation/OAuthController.java
+++ b/src/main/java/com/spring/blog/authentication/presentation/OAuthController.java
@@ -1,0 +1,38 @@
+package com.spring.blog.authentication.presentation;
+
+import com.spring.blog.authentication.application.OAuthService;
+import com.spring.blog.authentication.application.dto.TokenDto;
+import com.spring.blog.authentication.presentation.dto.OAuthLoginUrlResponse;
+import com.spring.blog.authentication.presentation.dto.OAuthTokenResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api")
+@RestController
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    public OAuthController(OAuthService oAuthService) {
+        this.oAuthService = oAuthService;
+    }
+
+    @GetMapping("/authorization/github")
+    public ResponseEntity<OAuthLoginUrlResponse> getGithubAuthorizationUrl() {
+        String githubAuthorizationUrl = oAuthService.getGithubAuthorizationUrl();
+        OAuthLoginUrlResponse oAuthLoginUrlResponse =
+            new OAuthLoginUrlResponse(githubAuthorizationUrl);
+        return ResponseEntity.ok(oAuthLoginUrlResponse);
+    }
+
+    @GetMapping("/afterlogin")
+    public ResponseEntity<OAuthTokenResponse> getLoginToken(@RequestParam String code) {
+        TokenDto tokenDto = oAuthService.createToken(code);
+        OAuthTokenResponse oAuthTokenResponse =
+            new OAuthTokenResponse(tokenDto.getToken(), tokenDto.getUserName());
+        return ResponseEntity.ok(oAuthTokenResponse);
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/presentation/dto/OAuthLoginUrlResponse.java
+++ b/src/main/java/com/spring/blog/authentication/presentation/dto/OAuthLoginUrlResponse.java
@@ -1,0 +1,17 @@
+package com.spring.blog.authentication.presentation.dto;
+
+public class OAuthLoginUrlResponse {
+
+    private String url;
+
+    private OAuthLoginUrlResponse() {
+    }
+
+    public OAuthLoginUrlResponse(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/com/spring/blog/authentication/presentation/dto/OAuthTokenResponse.java
+++ b/src/main/java/com/spring/blog/authentication/presentation/dto/OAuthTokenResponse.java
@@ -1,0 +1,23 @@
+package com.spring.blog.authentication.presentation.dto;
+
+public class OAuthTokenResponse {
+
+    private String token;
+    private String userName;
+
+    private OAuthTokenResponse() {
+    }
+
+    public OAuthTokenResponse(String token, String userName) {
+        this.token = token;
+        this.userName = userName;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+}

--- a/src/main/java/com/spring/blog/configuration/JpaConfiguration.java
+++ b/src/main/java/com/spring/blog/configuration/JpaConfiguration.java
@@ -1,0 +1,9 @@
+package com.spring.blog.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfiguration {
+}

--- a/src/main/java/com/spring/blog/configuration/QueryDSLConfiguration.java
+++ b/src/main/java/com/spring/blog/configuration/QueryDSLConfiguration.java
@@ -1,0 +1,19 @@
+package com.spring.blog.configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDSLConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/spring/blog/exception/authentication/AuthenticationException.java
+++ b/src/main/java/com/spring/blog/exception/authentication/AuthenticationException.java
@@ -1,0 +1,11 @@
+package com.spring.blog.exception.authentication;
+
+import com.spring.blog.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public abstract class AuthenticationException extends ApplicationException {
+
+    protected AuthenticationException(String message, String errorCode, HttpStatus httpStatus) {
+        super(message, errorCode, httpStatus);
+    }
+}

--- a/src/main/java/com/spring/blog/exception/authentication/InvalidTokenException.java
+++ b/src/main/java/com/spring/blog/exception/authentication/InvalidTokenException.java
@@ -1,0 +1,17 @@
+package com.spring.blog.exception.authentication;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidTokenException extends AuthenticationException {
+
+    private static final String INVALID_TOKEN_MESSAGE = "유효하지 않은 토큰입니다.";
+    private static final String INVALID_TOKEN_CODE = "A0001";
+
+    public InvalidTokenException() {
+        this(INVALID_TOKEN_MESSAGE, INVALID_TOKEN_CODE, HttpStatus.UNAUTHORIZED);
+    }
+
+    public InvalidTokenException(String message, String errorCode, HttpStatus httpStatus) {
+        super(message, errorCode, httpStatus);
+    }
+}

--- a/src/main/java/com/spring/blog/exception/platform/PlatformException.java
+++ b/src/main/java/com/spring/blog/exception/platform/PlatformException.java
@@ -1,0 +1,11 @@
+package com.spring.blog.exception.platform;
+
+import com.spring.blog.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public abstract class PlatformException extends ApplicationException {
+
+    protected PlatformException(String message, String errorCode, HttpStatus httpStatus) {
+        super(message, errorCode, httpStatus);
+    }
+}

--- a/src/main/java/com/spring/blog/exception/platform/PlatformHttpErrorException.java
+++ b/src/main/java/com/spring/blog/exception/platform/PlatformHttpErrorException.java
@@ -1,0 +1,21 @@
+package com.spring.blog.exception.platform;
+
+import org.springframework.http.HttpStatus;
+
+public class PlatformHttpErrorException extends PlatformException {
+
+    private static final String PLATFORM_HTTP_ERROR_MESSAGE = "외부 플랫폼 연동에 실패했습니다.";
+    private static final String PLATFORM_HTTP_ERROR_CODE = "P0001";
+
+    public PlatformHttpErrorException() {
+        this(
+            PLATFORM_HTTP_ERROR_MESSAGE,
+            PLATFORM_HTTP_ERROR_CODE,
+            HttpStatus.INTERNAL_SERVER_ERROR
+        );
+    }
+
+    public PlatformHttpErrorException(String message, String errorCode, HttpStatus httpStatus) {
+        super(message, errorCode, httpStatus);
+    }
+}

--- a/src/main/java/com/spring/blog/user/domain/User.java
+++ b/src/main/java/com/spring/blog/user/domain/User.java
@@ -1,0 +1,32 @@
+package com.spring.blog.user.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    private String profileImage;
+
+    protected User() {
+    }
+
+    public User(String name, String profileImage) {
+        this.name = name;
+        this.profileImage = profileImage;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/spring/blog/user/domain/repoistory/UserRepository.java
+++ b/src/main/java/com/spring/blog/user/domain/repoistory/UserRepository.java
@@ -1,0 +1,10 @@
+package com.spring.blog.user.domain.repoistory;
+
+import com.spring.blog.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByName(String name);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,3 @@
-
+spring:
+  profiles:
+    include: security

--- a/src/test/java/com/spring/blog/authentication/acceptance/OAuthAcceptanceTest.java
+++ b/src/test/java/com/spring/blog/authentication/acceptance/OAuthAcceptanceTest.java
@@ -1,0 +1,48 @@
+package com.spring.blog.authentication.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spring.blog.authentication.presentation.dto.OAuthLoginUrlResponse;
+import com.spring.blog.common.AcceptanceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+class OAuthAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @DisplayName("Github Login Url을 요청한다.")
+    @Test
+    void getGithubAuthorizationUrl_Valid_Success() {
+        // given, when, then
+        webTestClient.get()
+            .uri("/api/authorization/github")
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .is2xxSuccessful()
+            .expectBody(OAuthLoginUrlResponse.class)
+            .consumeWith(response -> {
+                String url = response.getResponseBody().getUrl();
+                assertThat(url).isEqualTo("https://api.github.com/authorize?");
+            });
+    }
+
+    @DisplayName("Github Login 완료 후 토큰을 생성한다.")
+    @Test
+    void getLoginToken_Valid_Success() {
+        // given, when, then
+        webTestClient.get()
+            .uri("/api/afterlogin?code={code}", "kevin")
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .is2xxSuccessful()
+            .expectBody()
+            .jsonPath("$.userName", "kevin");
+    }
+}

--- a/src/test/java/com/spring/blog/authentication/application/OAuthServiceTest.java
+++ b/src/test/java/com/spring/blog/authentication/application/OAuthServiceTest.java
@@ -1,0 +1,191 @@
+package com.spring.blog.authentication.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.spring.blog.authentication.application.dto.TokenDto;
+import com.spring.blog.authentication.domain.JwtTokenProvider;
+import com.spring.blog.authentication.domain.OAuthClient;
+import com.spring.blog.authentication.domain.user.UserProfile;
+import com.spring.blog.exception.platform.PlatformHttpErrorException;
+import com.spring.blog.user.domain.User;
+import com.spring.blog.user.domain.repoistory.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@DisplayName("OAuthService 슬라이스 테스트")
+@ExtendWith(MockitoExtension.class)
+class OAuthServiceTest {
+
+    @InjectMocks
+    private OAuthService oAuthService;
+
+    @Mock
+    private OAuthClient oAuthClient;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @DisplayName("getGithubAuthorizationUrl 메서드는")
+    @Nested
+    class Describe_getGithubAuthorizationUrl {
+
+        @DisplayName("요청이 들어올 때")
+        @Nested
+        class Context_given_request {
+
+            @DisplayName("Authorization URL을 반환한다.")
+            @Test
+            void it_returns_authorization_url() {
+                // given
+                String url = "https://github.com/authorize";
+                given(oAuthClient.getLoginUrl()).willReturn(url);
+
+                // when
+                String githubAuthorizationUrl = oAuthService.getGithubAuthorizationUrl();
+
+                // then
+                assertThat(githubAuthorizationUrl).isEqualTo(url);
+
+                verify(oAuthClient, times(1)).getLoginUrl();
+            }
+        }
+    }
+
+    @DisplayName("createToken 메서드는")
+    @Nested
+    class Describe_createToken {
+
+        @DisplayName("유효한 Code값이 아니라면")
+        @Nested
+        class Context_invalid_code {
+
+            @DisplayName("Github Access Token을 가져오지 못하고 예외가 발생한다.")
+            @Test
+            void it_throws_PlatformHttpErrorException() {
+                // given
+                String invalidCode = "abc";
+                given(oAuthClient.getAccessToken(invalidCode))
+                    .willThrow(new PlatformHttpErrorException());
+
+                // when, then
+                assertThatCode(() -> oAuthService.createToken(invalidCode))
+                    .isInstanceOf(PlatformHttpErrorException.class)
+                    .hasMessage("외부 플랫폼 연동에 실패했습니다.")
+                    .hasFieldOrPropertyWithValue("errorCode", "P0001")
+                    .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR);
+
+                verify(oAuthClient, times(1)).getAccessToken(invalidCode);
+            }
+        }
+
+        @DisplayName("유효한 Code이더라도 외부 플랫폼에서 해당 회원을 조회하지 못하면")
+        @Nested
+        class Context_valid_code_but_user_profile_not_found {
+
+            @DisplayName("예외가 발생한다.")
+            @Test
+            void it_throws_PlatformHttpErrorException() {
+                // given
+                String validCode = "valid code";
+                String validAccessToken = "valid access token";
+                given(oAuthClient.getAccessToken(validCode)).willReturn(validAccessToken);
+                given(oAuthClient.getUserProfile(validAccessToken))
+                    .willThrow(new PlatformHttpErrorException());
+
+                // when, then
+                assertThatCode(() -> oAuthService.createToken(validCode))
+                    .isInstanceOf(PlatformHttpErrorException.class)
+                    .hasMessage("외부 플랫폼 연동에 실패했습니다.")
+                    .hasFieldOrPropertyWithValue("errorCode", "P0001")
+                    .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR);
+
+                verify(oAuthClient, times(1)).getAccessToken(validCode);
+                verify(oAuthClient, times(1)).getUserProfile(validAccessToken);
+            }
+        }
+
+        @DisplayName("외부 플랫폼에서 조회한 회원이 신규 유저라면")
+        @Nested
+        class Context_valid_code_and_new_user {
+
+            @DisplayName("신규 유저를 DB에 저장한다.")
+            @Test
+            void it_saves_new_user() {
+                // given
+                String validCode = "valid code";
+                String validAccessToken = "valid access token";
+                String userName = "kevin";
+                String jwtToken = "jwt.token";
+                UserProfile userProfile = new UserProfile(userName, "image");
+                given(oAuthClient.getAccessToken(validCode)).willReturn(validAccessToken);
+                given(oAuthClient.getUserProfile(validAccessToken)).willReturn(userProfile);
+                given(userRepository.findByName(userName)).willReturn(Optional.empty());
+                given(jwtTokenProvider.createToken(userName)).willReturn(jwtToken);
+
+                // when
+                TokenDto tokenDto = oAuthService.createToken(validCode);
+
+                // then
+                assertThat(tokenDto)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new TokenDto(jwtToken, userName));
+
+                verify(oAuthClient, times(1)).getAccessToken(validCode);
+                verify(oAuthClient, times(1)).getUserProfile(validAccessToken);
+                verify(userRepository, times(1)).findByName(userName);
+                verify(userRepository, times(1)).save(any(User.class));
+                verify(jwtTokenProvider, times(1)).createToken(userName);
+            }
+        }
+
+        @DisplayName("외부 플랫폼에서 조회한 회원이 이미 등록된 유저라면")
+        @Nested
+        class Context_valid_code_and_already_existing_user {
+
+            @DisplayName("DB에 저장하지 않는다.")
+            @Test
+            void it_does_not_save_new_user() {
+                // given
+                String validCode = "valid code";
+                String validAccessToken = "valid access token";
+                String userName = "kevin";
+                String jwtToken = "jwt.token";
+                UserProfile userProfile = new UserProfile(userName, "image");
+                User user = new User(userName, "image");
+                given(oAuthClient.getAccessToken(validCode)).willReturn(validAccessToken);
+                given(oAuthClient.getUserProfile(validAccessToken)).willReturn(userProfile);
+                given(userRepository.findByName(userName)).willReturn(Optional.of(user));
+                given(jwtTokenProvider.createToken(userName)).willReturn(jwtToken);
+
+                // when
+                TokenDto tokenDto = oAuthService.createToken(validCode);
+
+                // then
+                assertThat(tokenDto)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new TokenDto(jwtToken, userName));
+
+                verify(oAuthClient, times(1)).getAccessToken(validCode);
+                verify(oAuthClient, times(1)).getUserProfile(validAccessToken);
+                verify(userRepository, times(1)).findByName(userName);
+                verify(userRepository, times(0)).save(any(User.class));
+                verify(jwtTokenProvider, times(1)).createToken(userName);
+            }
+        }
+    }
+}

--- a/src/test/java/com/spring/blog/authentication/integration/OAuthServiceIntegrationTest.java
+++ b/src/test/java/com/spring/blog/authentication/integration/OAuthServiceIntegrationTest.java
@@ -25,10 +25,15 @@ class OAuthServiceIntegrationTest {
     private OAuthService oAuthService;
 
     @Autowired
-    private DatabaseCleaner databaseCleaner;
+    private UserRepository userRepository;
 
     @Autowired
-    private UserRepository userRepository;
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.execute();
+    }
 
     @DisplayName("Github Login Url을 요청한다.")
     @Test
@@ -38,11 +43,6 @@ class OAuthServiceIntegrationTest {
 
         // then
         assertThat(githubAuthorizationUrl).isEqualTo("https://api.github.com/authorize?");
-    }
-
-    @AfterEach
-    void tearDown() {
-        databaseCleaner.execute();
     }
 
     @DisplayName("외부 플랫폼에서 조회한 유저가 신규 유저면 DB에 저장한다.")

--- a/src/test/java/com/spring/blog/authentication/integration/OAuthServiceIntegrationTest.java
+++ b/src/test/java/com/spring/blog/authentication/integration/OAuthServiceIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.spring.blog.authentication.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spring.blog.authentication.application.OAuthService;
+import com.spring.blog.common.DatabaseCleaner;
+import com.spring.blog.configuration.InfrastructureTestConfiguration;
+import com.spring.blog.user.domain.repoistory.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("OAuthService 통합 테스트")
+@ActiveProfiles("test")
+@Import(InfrastructureTestConfiguration.class)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class OAuthServiceIntegrationTest {
+
+    @Autowired
+    private OAuthService oAuthService;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("Github Login Url을 요청한다.")
+    @Test
+    void getGithubAuthorizationUrl_Mock_Success() {
+        // given, when
+        String githubAuthorizationUrl = oAuthService.getGithubAuthorizationUrl();
+
+        // then
+        assertThat(githubAuthorizationUrl).isEqualTo("https://api.github.com/authorize?");
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.execute();
+    }
+
+    @DisplayName("외부 플랫폼에서 조회한 유저가 신규 유저면 DB에 저장한다.")
+    @Test
+    void createToken_NewUser_Save() {
+        // given
+        String code = "kevin";
+        boolean before = userRepository.findByName(code)
+            .isPresent();
+
+        // when
+        oAuthService.createToken(code);
+
+        // then
+        assertThat(userRepository.findByName(code)).isNotEmpty();
+    }
+}

--- a/src/test/java/com/spring/blog/authentication/presentation/OAuthControllerTest.java
+++ b/src/test/java/com/spring/blog/authentication/presentation/OAuthControllerTest.java
@@ -1,0 +1,58 @@
+package com.spring.blog.authentication.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.spring.blog.authentication.application.OAuthService;
+import com.spring.blog.authentication.application.dto.TokenDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OAuthController.class)
+class OAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OAuthService oAuthService;
+
+    @DisplayName("Github Login URL을 요청한다.")
+    @Test
+    void getGithubAuthorizationUrl_Valid_Success() throws Exception {
+        // given
+        given(oAuthService.getGithubAuthorizationUrl()).willReturn("https://github.com/authorize");
+
+        // when, then
+        mockMvc.perform(get("/api/authorization/github"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.url").value("https://github.com/authorize"));
+
+        verify(oAuthService, times(1)).getGithubAuthorizationUrl();
+    }
+
+    @DisplayName("Github Login 인증 후 Token을 반환한다.")
+    @Test
+    void getLoginToken_Valid_Success() throws Exception {
+        // given
+        String code = "code.123.for.github";
+        TokenDto tokenDto = new TokenDto("user jwt token", "kevin");
+        given(oAuthService.createToken(code)).willReturn(tokenDto);
+
+        // when, then
+        mockMvc.perform(get("/api/afterlogin?code={code}", code))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.token").value("user jwt token"))
+            .andExpect(jsonPath("$.userName").value("kevin"));
+
+        verify(oAuthService, times(1)).createToken(code);
+    }
+}

--- a/src/test/java/com/spring/blog/common/AcceptanceTest.java
+++ b/src/test/java/com/spring/blog/common/AcceptanceTest.java
@@ -1,0 +1,25 @@
+package com.spring.blog.common;
+
+import com.spring.blog.configuration.InfrastructureTestConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@Import(InfrastructureTestConfiguration.class)
+@ActiveProfiles("test")
+@AutoConfigureWebTestClient
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class AcceptanceTest {
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.execute();;
+    }
+}

--- a/src/test/java/com/spring/blog/common/DatabaseCleaner.java
+++ b/src/test/java/com/spring/blog/common/DatabaseCleaner.java
@@ -1,0 +1,61 @@
+package com.spring.blog.common;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+
+@Component
+@ActiveProfiles("test")
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        entityManager.unwrap(Session.class)
+            .doWork(this::extractTableNames);
+    }
+
+    private void extractTableNames(Connection conn) throws SQLException {
+        List<String> tableNames = new ArrayList<>();
+
+        ResultSet tables = conn
+            .getMetaData()
+            .getTables(conn.getCatalog(), null, "%", new String[]{"TABLE"});
+
+        while(tables.next()) {
+            tableNames.add(tables.getString("table_name"));
+        }
+
+        this.tableNames = tableNames;
+    }
+
+    public void execute() {
+        entityManager.unwrap(Session.class)
+            .doWork(this::cleanUpDatabase);
+    }
+
+    private void cleanUpDatabase(Connection conn) throws SQLException {
+        Statement statement = conn.createStatement();
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY FALSE");
+
+        for (String tableName : tableNames) {
+            statement.executeUpdate("TRUNCATE TABLE " + tableName);
+            statement.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1");
+        }
+
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+}

--- a/src/test/java/com/spring/blog/common/mock/MockGithubOAuthClient.java
+++ b/src/test/java/com/spring/blog/common/mock/MockGithubOAuthClient.java
@@ -1,0 +1,22 @@
+package com.spring.blog.common.mock;
+
+import com.spring.blog.authentication.domain.OAuthClient;
+import com.spring.blog.authentication.domain.user.UserProfile;
+
+public class MockGithubOAuthClient implements OAuthClient {
+
+    @Override
+    public String getLoginUrl() {
+        return "https://api.github.com/authorize?";
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        return code;
+    }
+
+    @Override
+    public UserProfile getUserProfile(String accessToken) {
+        return new UserProfile(accessToken, "image.url");
+    }
+}

--- a/src/test/java/com/spring/blog/configuration/InfrastructureTestConfiguration.java
+++ b/src/test/java/com/spring/blog/configuration/InfrastructureTestConfiguration.java
@@ -1,0 +1,15 @@
+package com.spring.blog.configuration;
+
+import com.spring.blog.authentication.domain.OAuthClient;
+import com.spring.blog.common.mock.MockGithubOAuthClient;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class InfrastructureTestConfiguration {
+
+    @Bean
+    public OAuthClient oAuthClient() {
+        return new MockGithubOAuthClient();
+    }
+}

--- a/src/test/java/com/spring/blog/configuration/JpaTestConfiguration.java
+++ b/src/test/java/com/spring/blog/configuration/JpaTestConfiguration.java
@@ -1,0 +1,9 @@
+package com.spring.blog.configuration;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@TestConfiguration
+public class JpaTestConfiguration {
+}


### PR DESCRIPTION
* User 엔티티 구현
* Github OAuth 로그인 구현 (JWT 활용)
  * 민감 정보는 서브 모듈을 통해 분리한다.
* Login API 구현
* 기타 Configuration
   * JPA Auditing
   * QueryDSL
 
Close #9 