### PR TITLE
[#84][feat/user-register] OAuth 기반 회원가입 기능 구현

### DIFF
--- a/backend/BOOT-INF/classes/static/docs/api.html
+++ b/backend/BOOT-INF/classes/static/docs/api.html
@@ -671,7 +671,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 235
+Content-Length: 234
 
 {
   "id" : 1,
@@ -680,8 +680,8 @@ Content-Length: 235
   "imageUrls" : [ "url1", "url2" ],
   "author" : "kevin",
   "viewCounts" : 0,
-  "createdDate" : "2021-08-31T10:46:21.977867",
-  "modifiedDate" : "2021-08-31T10:46:21.977881"
+  "createdDate" : "2021-09-03T16:07:21.251825",
+  "modifiedDate" : "2021-09-03T16:07:21.25184"
 }</code></pre>
 </div>
 </div>
@@ -1257,7 +1257,7 @@ Content-Length: 127
   "author" : "kevin",
   "content" : "comment hi",
   "depth" : 1,
-  "createdDate" : "2021-08-31T10:46:22.907448"
+  "createdDate" : "2021-09-03T16:07:22.631639"
 }</code></pre>
 </div>
 </div>
@@ -1367,7 +1367,7 @@ Content-Length: 127
   "author" : "kevin",
   "content" : "comment hi",
   "depth" : 2,
-  "createdDate" : "2021-08-31T10:46:22.896958"
+  "createdDate" : "2021-09-03T16:07:22.623357"
 }</code></pre>
 </div>
 </div>
@@ -1482,7 +1482,7 @@ Content-Length: 127
   "author" : "kevin",
   "content" : "comment hi",
   "depth" : 2,
-  "createdDate" : "2021-08-31T10:46:22.850835"
+  "createdDate" : "2021-09-03T16:07:22.582789"
 }</code></pre>
 </div>
 </div>

--- a/backend/src/docs/asciidoc/api.adoc
+++ b/backend/src/docs/asciidoc/api.adoc
@@ -3,6 +3,12 @@ ifndef::snippets[]
 endif::[]
 
 == User
+=== 회원가입 (OAuth)
+==== Request
+include::{snippets}/register-oauth/http-request.adoc[]
+==== Response
+include::{snippets}/register-oauth/http-response.adoc[]
+
 === 회원탈퇴 (비로그인)
 ==== Request
 include::{snippets}/withdraw-not-login/http-request.adoc[]

--- a/backend/src/main/java/com/spring/blog/authentication/domain/OAuthClient.java
+++ b/backend/src/main/java/com/spring/blog/authentication/domain/OAuthClient.java
@@ -4,6 +4,8 @@ import com.spring.blog.authentication.domain.user.UserProfile;
 
 public interface OAuthClient {
 
+    boolean matches(String name);
+
     String getLoginUrl();
 
     String getAccessToken(String code);

--- a/backend/src/main/java/com/spring/blog/authentication/domain/repository/OAuthClientRepository.java
+++ b/backend/src/main/java/com/spring/blog/authentication/domain/repository/OAuthClientRepository.java
@@ -1,0 +1,8 @@
+package com.spring.blog.authentication.domain.repository;
+
+import com.spring.blog.authentication.domain.OAuthClient;
+
+public interface OAuthClientRepository {
+
+    OAuthClient findByName(String name);
+}

--- a/backend/src/main/java/com/spring/blog/authentication/domain/repository/OAuthClientRepositoryImpl.java
+++ b/backend/src/main/java/com/spring/blog/authentication/domain/repository/OAuthClientRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.spring.blog.authentication.domain.repository;
+
+import com.spring.blog.authentication.domain.OAuthClient;
+import com.spring.blog.exception.authentication.InvalidOauthProviderException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class OAuthClientRepositoryImpl implements OAuthClientRepository {
+
+    private final List<OAuthClient> oAuthClients;
+
+    public OAuthClient findByName(String name) {
+        return oAuthClients.stream()
+            .filter(oAuthClient -> oAuthClient.matches(name))
+            .findAny()
+            .orElseThrow(InvalidOauthProviderException::new);
+    }
+}

--- a/backend/src/main/java/com/spring/blog/authentication/domain/user/UserProfile.java
+++ b/backend/src/main/java/com/spring/blog/authentication/domain/user/UserProfile.java
@@ -1,23 +1,33 @@
 package com.spring.blog.authentication.domain.user;
 
+import com.spring.blog.exception.authentication.RegistrationRequiredException;
+import java.util.Objects;
+
 public class UserProfile {
 
     private String name;
-    private String profileImageUrl;
+    private String email;
 
     private UserProfile() {
     }
 
-    public UserProfile(String name, String profileImageUrl) {
+    public UserProfile(String name, String email) {
+        validateEmail(email);
         this.name = name;
-        this.profileImageUrl = profileImageUrl;
+        this.email = email;
+    }
+
+    private void validateEmail(String email) {
+        if (Objects.isNull(email)) {
+            throw new RegistrationRequiredException(email);
+        }
     }
 
     public String getName() {
         return name;
     }
 
-    public String getProfileImageUrl() {
-        return profileImageUrl;
+    public String getEmail() {
+        return email;
     }
 }

--- a/backend/src/main/java/com/spring/blog/authentication/infrastructure/GithubOAuthClient.java
+++ b/backend/src/main/java/com/spring/blog/authentication/infrastructure/GithubOAuthClient.java
@@ -6,6 +6,7 @@ import com.spring.blog.authentication.infrastructure.dto.request.AccessTokenRequ
 import com.spring.blog.authentication.infrastructure.dto.response.AccessTokenResponseDto;
 import com.spring.blog.authentication.infrastructure.dto.response.UserProfileResponseDto;
 import com.spring.blog.exception.platform.PlatformHttpErrorException;
+import java.util.Locale;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -34,6 +35,11 @@ public class GithubOAuthClient implements OAuthClient {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.redirectUrl = redirectUrl;
+    }
+
+    @Override
+    public boolean matches(String name) {
+        return name.toUpperCase(Locale.ROOT).matches("GITHUB");
     }
 
     @Override
@@ -78,7 +84,7 @@ public class GithubOAuthClient implements OAuthClient {
                 .orElseThrow(PlatformHttpErrorException::new);
             return new UserProfile(
                 userProfileResponseDto.getName(),
-                userProfileResponseDto.getProfileImageUrl()
+                userProfileResponseDto.getEmail()
             );
         } catch (WebClientException webClientException) {
             throw new PlatformHttpErrorException();

--- a/backend/src/main/java/com/spring/blog/authentication/presentation/AuthController.java
+++ b/backend/src/main/java/com/spring/blog/authentication/presentation/AuthController.java
@@ -1,12 +1,13 @@
 package com.spring.blog.authentication.presentation;
 
-import com.spring.blog.authentication.application.OAuthService;
+import com.spring.blog.authentication.application.AuthService;
 import com.spring.blog.authentication.application.dto.TokenResponseDto;
 import com.spring.blog.authentication.presentation.dto.OAuthLoginUrlResponse;
 import com.spring.blog.authentication.presentation.dto.OAuthTokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,22 +15,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api")
 @RestController
-public class OAuthController {
+public class AuthController {
 
-    private final OAuthService oAuthService;
+    private final AuthService authService;
 
-    @GetMapping("/authorization/github")
-    public ResponseEntity<OAuthLoginUrlResponse> getGithubAuthorizationUrl() {
-        String githubAuthorizationUrl = oAuthService.getGithubAuthorizationUrl();
+    @GetMapping("/authorization/{oauthProvider}")
+    public ResponseEntity<OAuthLoginUrlResponse> getOAuthLoginUrl(
+        @PathVariable String oauthProvider
+    ) {
+        String oauthLoginUrl = authService.getOAuthLoginUrl(oauthProvider);
         OAuthLoginUrlResponse oAuthLoginUrlResponse = OAuthLoginUrlResponse.builder()
-            .url(githubAuthorizationUrl)
+            .url(oauthLoginUrl)
             .build();
         return ResponseEntity.ok(oAuthLoginUrlResponse);
     }
 
-    @GetMapping("/afterlogin")
-    public ResponseEntity<OAuthTokenResponse> getLoginToken(@RequestParam String code) {
-        TokenResponseDto tokenResponseDto = oAuthService.createToken(code);
+    @GetMapping("/{oauthProvider}/login")
+    public ResponseEntity<OAuthTokenResponse> loginByOauth(
+        @PathVariable String oauthProvider,
+        @RequestParam String code
+    ) {
+        TokenResponseDto tokenResponseDto = authService.loginByOauth(oauthProvider, code);
         OAuthTokenResponse oAuthTokenResponse = OAuthTokenResponse.builder()
             .token(tokenResponseDto.getToken())
             .userName(tokenResponseDto.getUserName())

--- a/backend/src/main/java/com/spring/blog/authentication/presentation/interceptor/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/spring/blog/authentication/presentation/interceptor/AuthenticationInterceptor.java
@@ -1,6 +1,6 @@
 package com.spring.blog.authentication.presentation.interceptor;
 
-import com.spring.blog.authentication.application.OAuthService;
+import com.spring.blog.authentication.application.AuthService;
 import com.spring.blog.authentication.presentation.util.AuthorizationExtractor;
 import com.spring.blog.exception.authentication.InvalidTokenException;
 import java.util.Objects;
@@ -18,7 +18,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     private static final Pattern COMMENT_IGNORE_PATTERN = Pattern.compile("/api/posts/.*/comments");
     private static final Pattern POST_IGNORE_PATTERN = Pattern.compile("/api/posts/.*");
 
-    private final OAuthService oAuthService;
+    private final AuthService authService;
 
     @Override
     public boolean preHandle(
@@ -33,7 +33,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             return true;
         }
         String token = AuthorizationExtractor.extract(request);
-        if (!oAuthService.validateToken(token)) {
+        if (!authService.validateToken(token)) {
             throw new InvalidTokenException();
         }
         request.setAttribute(HttpHeaders.AUTHORIZATION, token);

--- a/backend/src/main/java/com/spring/blog/authentication/presentation/resolver/AuthenticationPrincipalArgumentResolver.java
+++ b/backend/src/main/java/com/spring/blog/authentication/presentation/resolver/AuthenticationPrincipalArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.spring.blog.authentication.presentation.resolver;
 
-import com.spring.blog.authentication.application.OAuthService;
+import com.spring.blog.authentication.application.AuthService;
 import com.spring.blog.authentication.domain.Authenticated;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final OAuthService oAuthService;
+    private final AuthService authService;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -30,6 +30,6 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
     ) throws Exception {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         String token = (String) request.getAttribute(HttpHeaders.AUTHORIZATION);
-        return oAuthService.findRequestUserByToken(token);
+        return authService.findRequestUserByToken(token);
     }
 }

--- a/backend/src/main/java/com/spring/blog/configuration/WebConfiguration.java
+++ b/backend/src/main/java/com/spring/blog/configuration/WebConfiguration.java
@@ -1,6 +1,6 @@
 package com.spring.blog.configuration;
 
-import com.spring.blog.authentication.application.OAuthService;
+import com.spring.blog.authentication.application.AuthService;
 import com.spring.blog.authentication.presentation.interceptor.AuthenticationInterceptor;
 import com.spring.blog.authentication.presentation.resolver.AuthenticationPrincipalArgumentResolver;
 import java.util.List;
@@ -15,16 +15,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfiguration implements WebMvcConfigurer {
 
-    private final OAuthService oAuthService;
+    private final AuthService authService;
 
     @Bean
     public AuthenticationInterceptor authenticationInterceptor() {
-        return new AuthenticationInterceptor(oAuthService);
+        return new AuthenticationInterceptor(authService);
     }
 
     @Bean
     public AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver() {
-        return new AuthenticationPrincipalArgumentResolver(oAuthService);
+        return new AuthenticationPrincipalArgumentResolver(authService);
     }
 
     @Override
@@ -35,7 +35,7 @@ public class WebConfiguration implements WebMvcConfigurer {
             .addPathPatterns("/api/posts/*/comments/*/reply")
             .addPathPatterns("/api/comments/*")
             .addPathPatterns("/api/posts/*")
-            .addPathPatterns("/api/users/withdraw");
+            .addPathPatterns("/api/users");
     }
 
     @Override

--- a/backend/src/main/java/com/spring/blog/exception/GlobalExceptionAdvisor.java
+++ b/backend/src/main/java/com/spring/blog/exception/GlobalExceptionAdvisor.java
@@ -1,5 +1,6 @@
 package com.spring.blog.exception;
 
+import com.spring.blog.exception.authentication.RegistrationRequiredException;
 import com.spring.blog.exception.dto.ApiErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
@@ -14,6 +15,14 @@ public class GlobalExceptionAdvisor {
 
     private static final String LOG_FORMAT = "Class : {}, Code : {}, Message : {}";
     private static final String INTERNAL_SERVER_ERROR_CODE = "S0001";
+
+    @ExceptionHandler(RegistrationRequiredException.class)
+    public ResponseEntity<String> registrationRequiredException(RegistrationRequiredException e) {
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), e.getErrorCode(), e.getMessage());
+        return ResponseEntity
+            .status(e.getHttpStatus())
+            .body(e.getEmail());
+    }
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ApiErrorResponse> applicationException(ApplicationException e) {

--- a/backend/src/main/java/com/spring/blog/exception/authentication/InvalidOauthProviderException.java
+++ b/backend/src/main/java/com/spring/blog/exception/authentication/InvalidOauthProviderException.java
@@ -1,0 +1,17 @@
+package com.spring.blog.exception.authentication;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidOauthProviderException extends AuthenticationException {
+
+    private static final String ERROR_MESSAGE = "존재하지 않는 OAuth 서비스 제공자입니다.";
+    private static final String ERROR_CODE = "A0003";
+
+    public InvalidOauthProviderException() {
+        this(ERROR_MESSAGE, ERROR_CODE, HttpStatus.UNAUTHORIZED);
+    }
+
+    public InvalidOauthProviderException(String message, String errorCode, HttpStatus httpStatus) {
+        super(message, errorCode, httpStatus);
+    }
+}

--- a/backend/src/main/java/com/spring/blog/exception/authentication/RegistrationRequiredException.java
+++ b/backend/src/main/java/com/spring/blog/exception/authentication/RegistrationRequiredException.java
@@ -1,0 +1,31 @@
+package com.spring.blog.exception.authentication;
+
+import org.springframework.http.HttpStatus;
+
+public class RegistrationRequiredException extends AuthenticationException {
+
+    private static final String ERROR_MESSAGE =
+        "해당 소셜 계정으로 등록된 회원 정보가 없습니다. "
+            + "GitHub 계정의 경우 설정에서 이메일을 등록하셨는지 다시 확인해주세요.";
+    private static final String ERROR_CODE = "A0002";
+
+    private final String email;
+
+    public RegistrationRequiredException(String email) {
+        this(ERROR_MESSAGE, ERROR_CODE, HttpStatus.BAD_REQUEST, email);
+    }
+
+    public RegistrationRequiredException(
+        String message,
+        String errorCode,
+        HttpStatus httpStatus,
+        String email
+    ) {
+        super(message, errorCode, httpStatus);
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/backend/src/main/java/com/spring/blog/exception/user/ActiveAccountExistingException.java
+++ b/backend/src/main/java/com/spring/blog/exception/user/ActiveAccountExistingException.java
@@ -1,0 +1,17 @@
+package com.spring.blog.exception.user;
+
+import org.springframework.http.HttpStatus;
+
+public class ActiveAccountExistingException extends UserException {
+
+    private static final String ERROR_MESSAGE = "동일한 이메일로 등록된 회원 계정이 존재합니다.";
+    private static final String ERROR_CODE = "U0004";
+
+    public ActiveAccountExistingException() {
+        this(ERROR_MESSAGE, ERROR_CODE, HttpStatus.BAD_REQUEST);
+    }
+
+    public ActiveAccountExistingException(String message, String errorCode, HttpStatus httpStatus) {
+        super(message, errorCode, httpStatus);
+    }
+}

--- a/backend/src/main/java/com/spring/blog/exception/user/InvalidUserNameException.java
+++ b/backend/src/main/java/com/spring/blog/exception/user/InvalidUserNameException.java
@@ -1,0 +1,17 @@
+package com.spring.blog.exception.user;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidUserNameException extends UserException {
+
+    private static final String ERROR_MESSAGE = "유저 이름은 2~10자입니다.";
+    private static final String ERROR_CODE = "U0002";
+
+    public InvalidUserNameException() {
+        this(ERROR_MESSAGE, ERROR_CODE, HttpStatus.NOT_FOUND);
+    }
+
+    public InvalidUserNameException(String message, String errorCode, HttpStatus httpStatus) {
+        super(message, errorCode, httpStatus);
+    }
+}

--- a/backend/src/main/java/com/spring/blog/exception/user/NameDuplicationException.java
+++ b/backend/src/main/java/com/spring/blog/exception/user/NameDuplicationException.java
@@ -1,0 +1,17 @@
+package com.spring.blog.exception.user;
+
+import org.springframework.http.HttpStatus;
+
+public class NameDuplicationException extends UserException {
+
+    private static final String ERROR_MESSAGE = "중복된 이름입니다.";
+    private static final String ERROR_CODE = "U0003";
+
+    public NameDuplicationException() {
+        this(ERROR_MESSAGE, ERROR_CODE, HttpStatus.BAD_REQUEST);
+    }
+
+    public NameDuplicationException(String message, String errorCode, HttpStatus httpStatus) {
+        super(message, errorCode, httpStatus);
+    }
+}

--- a/backend/src/main/java/com/spring/blog/page/presentation/PageController.java
+++ b/backend/src/main/java/com/spring/blog/page/presentation/PageController.java
@@ -2,6 +2,7 @@ package com.spring.blog.page.presentation;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping("/page")
@@ -13,8 +14,13 @@ public class PageController {
         return "auth.html";
     }
 
-    @GetMapping("/post")
-    public String moveToPostPage() {
+    @GetMapping("/user/register")
+    public String moveToReigsterPage() {
+        return "user-register-oauth.html";
+    }
+
+    @GetMapping("/post/{postId}")
+    public String moveToPostPage(@PathVariable Long postId) {
         return "post.html";
     }
 

--- a/backend/src/main/java/com/spring/blog/user/application/UserService.java
+++ b/backend/src/main/java/com/spring/blog/user/application/UserService.java
@@ -1,6 +1,7 @@
 package com.spring.blog.user.application;
 
 import com.spring.blog.exception.user.UserNotFoundException;
+import com.spring.blog.user.application.dto.UserRegistrationRequestDto;
 import com.spring.blog.user.domain.User;
 import com.spring.blog.user.domain.repoistory.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,5 +20,14 @@ public class UserService {
         User user = userRepository.findActiveUserById(id)
             .orElseThrow(UserNotFoundException::new);
         user.withdraw();
+    }
+
+    @Transactional
+    public void register(UserRegistrationRequestDto userRegistrationRequestDto) {
+        User user = new User(
+            userRegistrationRequestDto.getName(),
+            userRegistrationRequestDto.getEmail()
+        );
+        userRepository.save(user);
     }
 }

--- a/backend/src/main/java/com/spring/blog/user/application/UserService.java
+++ b/backend/src/main/java/com/spring/blog/user/application/UserService.java
@@ -1,9 +1,12 @@
 package com.spring.blog.user.application;
 
+import com.spring.blog.exception.user.ActiveAccountExistingException;
+import com.spring.blog.exception.user.NameDuplicationException;
 import com.spring.blog.exception.user.UserNotFoundException;
 import com.spring.blog.user.application.dto.UserRegistrationRequestDto;
 import com.spring.blog.user.domain.User;
 import com.spring.blog.user.domain.repoistory.UserRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,11 +26,21 @@ public class UserService {
     }
 
     @Transactional
-    public void register(UserRegistrationRequestDto userRegistrationRequestDto) {
-        User user = new User(
-            userRegistrationRequestDto.getName(),
-            userRegistrationRequestDto.getEmail()
-        );
-        userRepository.save(user);
+    public void registerByOauth(UserRegistrationRequestDto userRegistrationRequestDto) {
+        String name = userRegistrationRequestDto.getName();
+        String email = userRegistrationRequestDto.getEmail();
+        validateDuplication(name, email);
+        userRepository.save(new User(name, email));
+    }
+
+    private void validateDuplication(String name, String email) {
+        Optional<User> user = userRepository.findByName(name);
+        if (user.isPresent()) {
+            throw new NameDuplicationException();
+        }
+        Optional<User> activeUser = userRepository.findActiveUserByEmail(email);
+        if (activeUser.isPresent()) {
+            throw new ActiveAccountExistingException();
+        }
     }
 }

--- a/backend/src/main/java/com/spring/blog/user/application/dto/UserRegistrationRequestDto.java
+++ b/backend/src/main/java/com/spring/blog/user/application/dto/UserRegistrationRequestDto.java
@@ -1,21 +1,17 @@
-package com.spring.blog.authentication.infrastructure.dto.response;
+package com.spring.blog.user.application.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @Builder
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserProfileResponseDto {
+public class UserRegistrationRequestDto {
 
-    @JsonProperty("login")
     private String name;
-
-    @JsonProperty("email")
     private String email;
 }

--- a/backend/src/main/java/com/spring/blog/user/domain/User.java
+++ b/backend/src/main/java/com/spring/blog/user/domain/User.java
@@ -17,7 +17,8 @@ public class User {
     @Column(unique = true, nullable = false)
     private String name;
 
-    private String profileImage;
+    @Column(nullable = false)
+    private String email;
 
     @Column(nullable = false)
     private Boolean isDeleted;
@@ -25,18 +26,15 @@ public class User {
     protected User() {
     }
 
-    public User(String name, String profileImage) {
-        this(null, name, profileImage);
+    //todo 이름 검증 필요
+    public User(String name, String email) {
+        this(null, name, email);
     }
 
-    public User(Long id, String name, String profileImage) {
+    public User(Long id, String name, String email) {
         this.id = id;
         this.name = name;
-        this.profileImage = profileImage;
-        this.isDeleted = false;
-    }
-
-    public void activate() {
+        this.email = email;
         this.isDeleted = false;
     }
 

--- a/backend/src/main/java/com/spring/blog/user/domain/User.java
+++ b/backend/src/main/java/com/spring/blog/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.spring.blog.user.domain;
 
+import com.spring.blog.exception.user.InvalidUserNameException;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -10,11 +11,14 @@ import javax.persistence.Id;
 @Entity
 public class User {
 
+    private static final int MAX_NAME_LENGTH = 10;
+    private static final int MIN_NAME_LENGTH = 2;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true, nullable = false, length = 10)
     private String name;
 
     @Column(nullable = false)
@@ -26,16 +30,23 @@ public class User {
     protected User() {
     }
 
-    //todo 이름 검증 필요
     public User(String name, String email) {
         this(null, name, email);
     }
 
     public User(Long id, String name, String email) {
+        validateName(name);
         this.id = id;
         this.name = name;
         this.email = email;
         this.isDeleted = false;
+    }
+
+    private void validateName(String name) {
+        int nameLength = name.trim().length();
+        if (nameLength < MIN_NAME_LENGTH || nameLength > MAX_NAME_LENGTH) {
+            throw new InvalidUserNameException();
+        }
     }
 
     public void withdraw() {

--- a/backend/src/main/java/com/spring/blog/user/domain/repoistory/CustomUserRepository.java
+++ b/backend/src/main/java/com/spring/blog/user/domain/repoistory/CustomUserRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 public interface CustomUserRepository {
 
     Optional<User> findActiveUserById(Long id);
+    Optional<User> findActiveUserByName(String name);
+    Optional<User> findActiveUserByEmail(String email);
 }

--- a/backend/src/main/java/com/spring/blog/user/domain/repoistory/CustomUserRepositoryImpl.java
+++ b/backend/src/main/java/com/spring/blog/user/domain/repoistory/CustomUserRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.spring.blog.user.domain.repoistory;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.spring.blog.user.domain.QUser;
 import com.spring.blog.user.domain.User;
@@ -11,35 +12,38 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class CustomUserRepositoryImpl implements CustomUserRepository {
 
+    private static final QUser QUSER = QUser.user;
+
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public Optional<User> findActiveUserById(Long id) {
-        QUser user = QUser.user;
-        User findUser = jpaQueryFactory.selectFrom(user)
-            .where(user.id.eq(id)
-                .and(user.isDeleted.eq(false)))
-            .fetchFirst();
+        User findUser = jpaQueryFactory.selectFrom(QUSER)
+            .where(QUSER.id.eq(id)
+                .and(isActiveUser()))
+            .fetchOne();
         return Optional.ofNullable(findUser);
     }
 
     @Override
     public Optional<User> findActiveUserByName(String name) {
-        QUser user = QUser.user;
-        User findUser = jpaQueryFactory.selectFrom(user)
-            .where(user.name.eq(name)
-                .and(user.isDeleted.eq(false)))
-            .fetchFirst();
+        User findUser = jpaQueryFactory.selectFrom(QUSER)
+            .where(QUSER.name.eq(name)
+                .and(isActiveUser()))
+            .fetchOne();
         return Optional.ofNullable(findUser);
     }
 
     @Override
     public Optional<User> findActiveUserByEmail(String email) {
-        QUser user = QUser.user;
-        User findUser = jpaQueryFactory.selectFrom(user)
-            .where(user.email.eq(email)
-                .and(user.isDeleted.eq(false)))
-            .fetchFirst();
+        User findUser = jpaQueryFactory.selectFrom(QUSER)
+            .where(QUSER.email.eq(email)
+                .and(isActiveUser()))
+            .fetchOne();
         return Optional.ofNullable(findUser);
+    }
+
+    private BooleanExpression isActiveUser() {
+        return QUSER.isDeleted.eq(false);
     }
 }

--- a/backend/src/main/java/com/spring/blog/user/domain/repoistory/CustomUserRepositoryImpl.java
+++ b/backend/src/main/java/com/spring/blog/user/domain/repoistory/CustomUserRepositoryImpl.java
@@ -22,4 +22,24 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
             .fetchFirst();
         return Optional.ofNullable(findUser);
     }
+
+    @Override
+    public Optional<User> findActiveUserByName(String name) {
+        QUser user = QUser.user;
+        User findUser = jpaQueryFactory.selectFrom(user)
+            .where(user.name.eq(name)
+                .and(user.isDeleted.eq(false)))
+            .fetchFirst();
+        return Optional.ofNullable(findUser);
+    }
+
+    @Override
+    public Optional<User> findActiveUserByEmail(String email) {
+        QUser user = QUser.user;
+        User findUser = jpaQueryFactory.selectFrom(user)
+            .where(user.email.eq(email)
+                .and(user.isDeleted.eq(false)))
+            .fetchFirst();
+        return Optional.ofNullable(findUser);
+    }
 }

--- a/backend/src/main/java/com/spring/blog/user/domain/repoistory/UserRepository.java
+++ b/backend/src/main/java/com/spring/blog/user/domain/repoistory/UserRepository.java
@@ -1,10 +1,7 @@
 package com.spring.blog.user.domain.repoistory;
 
 import com.spring.blog.user.domain.User;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long>, CustomUserRepository {
-
-    Optional<User> findByName(String name);
 }

--- a/backend/src/main/java/com/spring/blog/user/domain/repoistory/UserRepository.java
+++ b/backend/src/main/java/com/spring/blog/user/domain/repoistory/UserRepository.java
@@ -1,7 +1,10 @@
 package com.spring.blog.user.domain.repoistory;
 
 import com.spring.blog.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long>, CustomUserRepository {
+
+    Optional<User> findByName(String name);
 }

--- a/backend/src/main/java/com/spring/blog/user/presentation/UserController.java
+++ b/backend/src/main/java/com/spring/blog/user/presentation/UserController.java
@@ -3,9 +3,14 @@ package com.spring.blog.user.presentation;
 import com.spring.blog.authentication.domain.Authenticated;
 import com.spring.blog.authentication.domain.user.AppUser;
 import com.spring.blog.user.application.UserService;
+import com.spring.blog.user.application.dto.UserRegistrationRequestDto;
+import com.spring.blog.user.presentation.dto.UserRegistrationRequest;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,7 +21,19 @@ public class UserController {
 
     private final UserService userService;
 
-    @DeleteMapping("/users/withdraw")
+    @PostMapping("/users/oauth")
+    public ResponseEntity<Void> registerByOauth(
+        @RequestBody UserRegistrationRequest userRegistrationRequest
+    ) {
+        UserRegistrationRequestDto userRegistrationRequestDto = UserRegistrationRequestDto.builder()
+            .email(userRegistrationRequest.getEmail())
+            .name(userRegistrationRequest.getName())
+            .build();
+        userService.register(userRegistrationRequestDto);
+        return ResponseEntity.created(URI.create("/")).build();
+    }
+
+    @DeleteMapping("/users")
     public ResponseEntity<Void> delete(@Authenticated AppUser appUser) {
         userService.withdraw(appUser.getId());
         return ResponseEntity.noContent()

--- a/backend/src/main/java/com/spring/blog/user/presentation/UserController.java
+++ b/backend/src/main/java/com/spring/blog/user/presentation/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
             .email(userRegistrationRequest.getEmail())
             .name(userRegistrationRequest.getName())
             .build();
-        userService.register(userRegistrationRequestDto);
+        userService.registerByOauth(userRegistrationRequestDto);
         return ResponseEntity.created(URI.create("/")).build();
     }
 

--- a/backend/src/main/java/com/spring/blog/user/presentation/dto/UserRegistrationRequest.java
+++ b/backend/src/main/java/com/spring/blog/user/presentation/dto/UserRegistrationRequest.java
@@ -1,21 +1,23 @@
-package com.spring.blog.authentication.infrastructure.dto.response;
+package com.spring.blog.user.presentation.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @Builder
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserProfileResponseDto {
+public class UserRegistrationRequest {
 
-    @JsonProperty("login")
+    @NotBlank
     private String name;
 
-    @JsonProperty("email")
+    @NotBlank
+    @Email
     private String email;
 }

--- a/backend/src/main/java/com/spring/blog/user/presentation/dto/UserRegistrationRequest.java
+++ b/backend/src/main/java/com/spring/blog/user/presentation/dto/UserRegistrationRequest.java
@@ -2,6 +2,7 @@ package com.spring.blog.user.presentation.dto;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 public class UserRegistrationRequest {
 
     @NotBlank
+    @Pattern(regexp = "[a-zA-Z가-힣]{2,10}")
     private String name;
 
     @NotBlank

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,4 @@
 spring:
   profiles:
     include: security
+    active: test

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -42,8 +42,8 @@ create table user
 (
     id            bigint       not null auto_increment,
     is_deleted    bit          not null,
-    name          varchar(255) not null,
-    profile_image varchar(255),
+    name          varchar(10) not null,
+    email         varchar(255) not null,
     primary key (id)
 );
 

--- a/backend/src/main/resources/static/js/auth.js
+++ b/backend/src/main/resources/static/js/auth.js
@@ -1,15 +1,22 @@
 async function requestLoginToken() {
   const code = searchParam('code');
 
-  await axios.get('/api/afterlogin?code=' + code)
+  await axios.get('/api/github/login?code=' + code)
   .then(response => {
     const data = response.data;
     localStorage.setItem('token', data.token);
     localStorage.setItem('userName', data.userName);
     window.location.replace('/');
   }).catch(error => {
-    alert(error);
-    window.location.replace('/');
+    if (error.response.status === 400 && error.response.data === '') {
+      alert('GitHub Account Setting에서 Email을 설정해주세요.');
+      window.location.replace('/');
+    }
+    if (error.response.status === 400 && error.response.data !== '') {
+      alert('해당 SNS 계정과 연동된 회원 정보가 없습니다. 회원 가입 페이지로 이동합니다.');
+      sessionStorage.setItem('email', error.response.data);
+      window.location.replace('/page/user/register');
+    }
   });
 }
 

--- a/backend/src/main/resources/static/js/index.js
+++ b/backend/src/main/resources/static/js/index.js
@@ -44,7 +44,7 @@ function renderPostRow(response) {
     const $post = document.getElementById(post.id);
     $post.addEventListener('click', e => {
       sessionStorage.setItem('post-id', post.id);
-      window.location.replace('/page/post')
+      window.location.replace('/page/post/' + post.id)
     });
   });
 }

--- a/backend/src/main/resources/static/js/post-write.js
+++ b/backend/src/main/resources/static/js/post-write.js
@@ -38,7 +38,7 @@ function moveToPostPage(response) {
   const lastIndex = location.lastIndexOf('/');
   const postId = location.substring(lastIndex + 1);
   sessionStorage.setItem('post-id', postId);
-  window.location.replace('/page/post')
+  window.location.replace('/page/post/' + postId)
 }
 
 validateState();

--- a/backend/src/main/resources/static/js/user-register-oauth.js
+++ b/backend/src/main/resources/static/js/user-register-oauth.js
@@ -1,0 +1,30 @@
+function initiate() {
+  document.getElementById('email').value = sessionStorage.getItem('email');
+}
+
+async function sendRequest() {
+  const name = document.getElementById('name').value;
+  const email = document.getElementById('email').value;
+  const json = JSON.stringify({name: name, email: email});
+  await axios.post('/api/users/oauth', json, {
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  }).then(response => {
+    alert('회원 가입이 완료되었습니다. 다시 로그인해주세요.');
+    sessionStorage.removeItem('email');
+    window.location.replace('/')
+  }).catch(error => {
+    alert(error.response.data);
+  });
+}
+
+function activateSubmitButton() {
+  const $button = document.getElementById('submit-button');
+  $button.addEventListener('click', ev => {
+    sendRequest();
+  });
+}
+
+initiate();
+activateSubmitButton();

--- a/backend/src/main/resources/templates/user-register-oauth.html
+++ b/backend/src/main/resources/templates/user-register-oauth.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Springboot Blog :: User Registration</title>
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+        rel="stylesheet">
+</head>
+<body>
+<div class="container">
+  <h1>Sign Up</h1>
+  <br>
+  <br>
+  <div class="col-md-6">
+    <form accept-charset="UTF-8" id="signup-form">
+      <div class="form-group">
+        <label for="name">Name</label>
+        <input autofocus class="form-control" id="name"
+               name="name" pattern="[a-zA-Z가-힣]{2,10}" placeholder="이름을 입력하세요." type="text">
+      </div>
+      <div class="form-group">
+        <label for="email">Email</label>
+        <input class="form-control" id="email" name="email" placeholder="이메일을 입력하세요." required type="text" readonly>
+      </div>
+      <div class="form-group">
+        <button class="btn btn-primary" id="submit-button">Sign Up</button>
+      </div>
+      <a class="btn btn-secondary" href="/" role="button">Cancel</a>
+    </form>
+  </div>
+</div>
+</body>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script type="module" src="/js/user-register-oauth.js"></script>
+</html>

--- a/backend/src/test/java/com/spring/blog/authentication/acceptance/OAuthAcceptanceTest.java
+++ b/backend/src/test/java/com/spring/blog/authentication/acceptance/OAuthAcceptanceTest.java
@@ -40,7 +40,7 @@ class OAuthAcceptanceTest extends AcceptanceTest {
     void getLoginToken_Valid_Success() {
         // given, when, then
         webTestClient.get()
-            .uri("/api/afterlogin?code={code}", "kevin")
+            .uri("/api/github/login?code={code}", "kevin")
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus()

--- a/backend/src/test/java/com/spring/blog/authentication/acceptance/OAuthAcceptanceTest.java
+++ b/backend/src/test/java/com/spring/blog/authentication/acceptance/OAuthAcceptanceTest.java
@@ -38,7 +38,10 @@ class OAuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("Github Login 완료 후 토큰을 생성한다.")
     @Test
     void getLoginToken_Valid_Success() {
-        // given, when, then
+        // given
+        api_회원_등록("kevin");
+
+        // when, then
         webTestClient.get()
             .uri("/api/github/login?code={code}", "kevin")
             .accept(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/spring/blog/authentication/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/spring/blog/authentication/application/AuthServiceTest.java
@@ -101,6 +101,7 @@ class AuthServiceTest {
                     .hasFieldOrPropertyWithValue("errorCode", "V0001")
                     .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR);
 
+                verify(oAuthClientRepository, times(1)).findByName("github");
                 verify(oAuthClient, times(1)).getAccessToken(invalidCode);
             }
         }
@@ -127,6 +128,7 @@ class AuthServiceTest {
                     .hasFieldOrPropertyWithValue("errorCode", "V0001")
                     .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.INTERNAL_SERVER_ERROR);
 
+                verify(oAuthClientRepository, times(1)).findByName("github");
                 verify(oAuthClient, times(1)).getAccessToken(validCode);
                 verify(oAuthClient, times(1)).getUserProfile(validAccessToken);
             }
@@ -155,6 +157,11 @@ class AuthServiceTest {
                     .isInstanceOf(RegistrationRequiredException.class)
                     .hasFieldOrPropertyWithValue("errorCode", "A0002")
                     .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.BAD_REQUEST);
+
+                verify(oAuthClientRepository, times(1)).findByName("github");
+                verify(oAuthClient, times(1)).getAccessToken(validCode);
+                verify(oAuthClient, times(1)).getUserProfile(validAccessToken);
+                verify(userRepository, times(1)).findActiveUserByEmail(email);
             }
         }
 
@@ -191,6 +198,7 @@ class AuthServiceTest {
                     .usingRecursiveComparison()
                     .isEqualTo(expected);
 
+                verify(oAuthClientRepository, times(1)).findByName("github");
                 verify(oAuthClient, times(1)).getAccessToken(validCode);
                 verify(oAuthClient, times(1)).getUserProfile(validAccessToken);
                 verify(userRepository, times(1)).findActiveUserByEmail(email);

--- a/backend/src/test/java/com/spring/blog/authentication/domain/user/UserProfileTest.java
+++ b/backend/src/test/java/com/spring/blog/authentication/domain/user/UserProfileTest.java
@@ -1,0 +1,22 @@
+package com.spring.blog.authentication.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.spring.blog.exception.authentication.RegistrationRequiredException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+@DisplayName("UserProfile 단위 테스트")
+class UserProfileTest {
+
+    @DisplayName("email이 null이면 예외가 발생한다.")
+    @Test
+    void newUserProfile_emailNull_ExceptionThrown() {
+        // given, when, then
+        assertThatCode(() -> new UserProfile("abc", null))
+            .isInstanceOf(RegistrationRequiredException.class)
+            .hasFieldOrPropertyWithValue("errorCode", "A0002")
+            .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/src/test/java/com/spring/blog/authentication/integration/AuthServiceIntegrationTest.java
+++ b/backend/src/test/java/com/spring/blog/authentication/integration/AuthServiceIntegrationTest.java
@@ -3,62 +3,76 @@ package com.spring.blog.authentication.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import com.spring.blog.authentication.application.OAuthService;
+import com.spring.blog.authentication.application.AuthService;
 import com.spring.blog.authentication.application.dto.TokenResponseDto;
 import com.spring.blog.authentication.domain.user.AppUser;
 import com.spring.blog.authentication.domain.user.LoginUser;
 import com.spring.blog.common.IntegrationTest;
 import com.spring.blog.exception.authentication.InvalidTokenException;
+import com.spring.blog.exception.authentication.RegistrationRequiredException;
+import com.spring.blog.user.domain.User;
 import com.spring.blog.user.domain.repoistory.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-@DisplayName("OAuthService 통합 테스트")
-class OAuthServiceIntegrationTest extends IntegrationTest {
+@DisplayName("AuthService 통합 테스트")
+class AuthServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
-    private OAuthService oAuthService;
+    private AuthService authService;
 
     @Autowired
     private UserRepository userRepository;
 
     @DisplayName("Github Login Url을 요청한다.")
     @Test
-    void getGithubAuthorizationUrl_Mock_Success() {
+    void getOauthLoginUrl_Mock_Success() {
         // given, when
-        String githubAuthorizationUrl = oAuthService.getGithubAuthorizationUrl();
+        String githubAuthorizationUrl = authService.getOAuthLoginUrl("github");
 
         // then
         assertThat(githubAuthorizationUrl).isEqualTo("https://api.github.com/authorize?");
     }
 
-    @DisplayName("외부 플랫폼에서 조회한 유저가 신규 유저면 DB에 저장한다.")
+    @DisplayName("외부 플랫폼에서 조회한 유저가 신규 유저면 예외가 발생한다.")
     @Test
-    void createToken_NewUser_Save() {
+    void loginByOauth_NewUser_ExceptionThrown() {
         // given
         String code = "kevin";
-        boolean before = userRepository.findByName(code)
-            .isPresent();
+
+        // when, then
+        assertThatCode(() -> authService.loginByOauth("github", code))
+            .isInstanceOf(RegistrationRequiredException.class)
+            .hasFieldOrPropertyWithValue("errorCode", "A0002")
+            .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.BAD_REQUEST);
+    }
+
+    @DisplayName("외부 플랫폼에서 조회한 유저가 db 존재하면 로그인 성공한다.")
+    @Test
+    void loginByOauth_ExistingUser_Success() {
+        // given
+        userRepository.save(new User("kevin", "kevin@naver.com"));
+        String code = "kevin";
 
         // when
-        oAuthService.createToken(code);
+        TokenResponseDto tokenResponseDto = authService.loginByOauth("github", code);
 
         // then
-        assertThat(before).isFalse();
-        assertThat(userRepository.findByName(code)).isNotEmpty();
+        assertThat(tokenResponseDto.getUserName()).isEqualTo("kevin");
     }
 
     @DisplayName("token 유효성 검사 : 유효하면 true를 반환한다.")
     @Test
     void validateToken_Valid_True() {
         // given
-        TokenResponseDto tokenResponseDto = oAuthService.createToken("kevin");
+        userRepository.save(new User("123", "123@naver.com"));
+        TokenResponseDto tokenResponseDto = authService.loginByOauth("github", "123");
         String token = tokenResponseDto.getToken();
 
         // when
-        boolean isValid = oAuthService.validateToken(token);
+        boolean isValid = authService.validateToken(token);
 
         // then
         assertThat(isValid).isTrue();
@@ -68,31 +82,32 @@ class OAuthServiceIntegrationTest extends IntegrationTest {
     @Test
     void validateToken_Valid_False() {
         // given, when, then
-        assertThat(oAuthService.validateToken("no")).isFalse();
+        assertThat(authService.validateToken("no")).isFalse();
     }
 
     @DisplayName("token이 유효하면 부합하는 AppUser를 반환한다.")
     @Test
     void findRequestUserByToken_Valid_AppUser() {
         // given
-        TokenResponseDto tokenResponseDto = oAuthService.createToken("kevin");
+        userRepository.save(new User("123", "123@naver.com"));
+        TokenResponseDto tokenResponseDto = authService.loginByOauth("github", "123");
         String token = tokenResponseDto.getToken();
 
         // when
-        AppUser appUser = oAuthService.findRequestUserByToken(token);
+        AppUser appUser = authService.findRequestUserByToken(token);
 
         // then
         assertThat(appUser)
             .usingRecursiveComparison()
             .ignoringFields("id")
-            .isEqualTo(new LoginUser(null, "kevin"));
+            .isEqualTo(new LoginUser(null, "123"));
     }
 
     @DisplayName("token이 유효하지 않으면 AppUser를 조회하지 못하고 예외가 발생한다.")
     @Test
     void findRequestUserByToken_Invalid_ExceptionThrown() {
         // given, when, then
-        assertThatCode(() -> oAuthService.findRequestUserByToken("invalid"))
+        assertThatCode(() -> authService.findRequestUserByToken("invalid"))
             .isInstanceOf(InvalidTokenException.class)
             .hasMessage("유효하지 않은 토큰입니다.")
             .hasFieldOrPropertyWithValue("errorCode", "A0001")

--- a/backend/src/test/java/com/spring/blog/comment/acceptance/CommentAcceptanceTest.java
+++ b/backend/src/test/java/com/spring/blog/comment/acceptance/CommentAcceptanceTest.java
@@ -25,6 +25,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
     @Test
     void write_LoginUser_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         String postId = api_테스트용_게시물_작성_ID_회수(token);
 
@@ -42,6 +43,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
     @Test
     void write_GuestUser_Fail() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         String postId = api_테스트용_게시물_작성_ID_회수(token);
         CommentWriteRequest commentWriteRequest = new CommentWriteRequest("comment!");
@@ -63,6 +65,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
     @Test
     void reply_LoginUser_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         String postId = api_테스트용_게시물_작성_ID_회수(token);
         Long commentId = api_테스트용_댓글_작성_ID_회수(token, postId);
@@ -81,6 +84,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
     @Test
     void reply_GuestUser_Fail() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         String postId = api_테스트용_게시물_작성_ID_회수(token);
         Long commentId = api_테스트용_댓글_작성_ID_회수(token, postId);
@@ -111,6 +115,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
     @Test
     void readList_Pagination_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         String postId = api_테스트용_게시물_작성_ID_회수(token);
 
@@ -166,6 +171,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
     @Test
     void edit_LoginUser_Failure() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         String postId = api_테스트용_게시물_작성_ID_회수(token);
         Long commentId = api_댓글_작성_요청_ID_회수(token, "first comment", postId);
@@ -206,6 +212,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
     @Test
     void delete_LoginUser_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         String postId = api_테스트용_게시물_작성_ID_회수(token);
         Long commentId = api_댓글_작성_요청_ID_회수(token, "first comment", postId);

--- a/backend/src/test/java/com/spring/blog/comment/domain/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/spring/blog/comment/domain/repository/CommentRepositoryTest.java
@@ -24,8 +24,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
 
 @DisplayName("CommentRepository 단위 테스트")
+@ActiveProfiles("test")
 @Import(JpaTestConfiguration.class)
 @DataJpaTest
 class CommentRepositoryTest {

--- a/backend/src/test/java/com/spring/blog/comment/presentation/CommentControllerTest.java
+++ b/backend/src/test/java/com/spring/blog/comment/presentation/CommentControllerTest.java
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.spring.blog.authentication.application.OAuthService;
+import com.spring.blog.authentication.application.AuthService;
 import com.spring.blog.authentication.domain.user.LoginUser;
 import com.spring.blog.comment.application.CommentService;
 import com.spring.blog.comment.application.dto.request.CommentDeleteRequestDto;
@@ -66,7 +66,7 @@ class CommentControllerTest {
     private CommentService commentService;
 
     @MockBean
-    private OAuthService oAuthService;
+    private AuthService authService;
 
     @DisplayName("비로그인 유저는 댓글을 작성할 수 없다.")
     @Test
@@ -78,7 +78,7 @@ class CommentControllerTest {
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.errorCode").value("A0001"));
 
-        verify(oAuthService, times(1)).validateToken(any());
+        verify(authService, times(1)).validateToken(any());
 
         // restDocs
         resultActions.andDo(document("comment-write-not-login",
@@ -102,8 +102,8 @@ class CommentControllerTest {
             .createdDate(LocalDateTime.now())
             .build();
 
-        given(oAuthService.validateToken("token")).willReturn(true);
-        given(oAuthService.findRequestUserByToken("token")).willReturn(new LoginUser(1L, "kevin"));
+        given(authService.validateToken("token")).willReturn(true);
+        given(authService.findRequestUserByToken("token")).willReturn(new LoginUser(1L, "kevin"));
         given(commentService.writeComment(any(CommentWriteRequestDto.class)))
             .willReturn(commentResponseDto);
 
@@ -118,8 +118,8 @@ class CommentControllerTest {
             .andExpect(jsonPath("$.content").value("comment hi"))
             .andExpect(jsonPath("$.depth").value("1"));
 
-        verify(oAuthService, times(1)).validateToken("token");
-        verify(oAuthService, times(1)).findRequestUserByToken("token");
+        verify(authService, times(1)).validateToken("token");
+        verify(authService, times(1)).findRequestUserByToken("token");
         verify(commentService, times(1))
             .writeComment(any(CommentWriteRequestDto.class));
 
@@ -140,7 +140,7 @@ class CommentControllerTest {
     @Test
     void reply_NotLoginUser_Fail() throws Exception {
         // given
-        given(oAuthService.validateToken(any())).willReturn(false);
+        given(authService.validateToken(any())).willReturn(false);
 
         // when, then
         ResultActions resultActions = mockMvc
@@ -150,7 +150,7 @@ class CommentControllerTest {
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.errorCode").value("A0001"));
 
-        verify(oAuthService, times(1)).validateToken(any());
+        verify(authService, times(1)).validateToken(any());
 
         // restDocs
         resultActions.andDo(document("comment-reply-not-login",
@@ -174,8 +174,8 @@ class CommentControllerTest {
             .createdDate(LocalDateTime.now())
             .build();
 
-        given(oAuthService.validateToken("token")).willReturn(true);
-        given(oAuthService.findRequestUserByToken("token")).willReturn(new LoginUser(1L, "kevin"));
+        given(authService.validateToken("token")).willReturn(true);
+        given(authService.findRequestUserByToken("token")).willReturn(new LoginUser(1L, "kevin"));
         given(commentService.replyComment(any(CommentReplyRequestDto.class)))
             .willReturn(commentResponseDto);
 
@@ -192,8 +192,8 @@ class CommentControllerTest {
             .andExpect(jsonPath("$.content").value("comment hi"))
             .andExpect(jsonPath("$.depth").value("2"));
 
-        verify(oAuthService, times(1)).validateToken("token");
-        verify(oAuthService, times(1)).findRequestUserByToken("token");
+        verify(authService, times(1)).validateToken("token");
+        verify(authService, times(1)).findRequestUserByToken("token");
         verify(commentService, times(1))
             .replyComment(any(CommentReplyRequestDto.class));
 
@@ -216,7 +216,7 @@ class CommentControllerTest {
         // given
         String requestBody =
             objectMapper.writeValueAsString(new CommentWriteRequest("comment hi"));
-        given(oAuthService.validateToken(any())).willReturn(false);
+        given(authService.validateToken(any())).willReturn(false);
 
         // when, then
         ResultActions resultActions = mockMvc.perform(put("/api/comments/{commentId}", "1")
@@ -226,7 +226,7 @@ class CommentControllerTest {
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.errorCode").value("A0001"));
 
-        verify(oAuthService, times(1)).validateToken(any());
+        verify(authService, times(1)).validateToken(any());
 
         // restDocs
         resultActions.andDo(document("comment-edit-not-login",
@@ -250,8 +250,8 @@ class CommentControllerTest {
             .createdDate(LocalDateTime.now())
             .build();
 
-        given(oAuthService.validateToken("token")).willReturn(true);
-        given(oAuthService.findRequestUserByToken("token")).willReturn(new LoginUser(1L, "kevin"));
+        given(authService.validateToken("token")).willReturn(true);
+        given(authService.findRequestUserByToken("token")).willReturn(new LoginUser(1L, "kevin"));
         given(commentService.editComment(any(CommentEditRequestDto.class)))
             .willReturn(commentResponseDto);
 
@@ -267,8 +267,8 @@ class CommentControllerTest {
             .andExpect(jsonPath("$.content").value("comment hi"))
             .andExpect(jsonPath("$.depth").value("2"));
 
-        verify(oAuthService, times(1)).validateToken("token");
-        verify(oAuthService, times(1)).findRequestUserByToken("token");
+        verify(authService, times(1)).validateToken("token");
+        verify(authService, times(1)).findRequestUserByToken("token");
         verify(commentService, times(1))
             .editComment(any(CommentEditRequestDto.class));
 
@@ -289,14 +289,14 @@ class CommentControllerTest {
     @Test
     void delete_GuestUser_Failure() throws Exception {
         // given
-        given(oAuthService.validateToken(any())).willReturn(false);
+        given(authService.validateToken(any())).willReturn(false);
 
         // when, then
         ResultActions resultActions = mockMvc.perform(delete("/api/comments/{commentId}", "1"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.errorCode").value("A0001"));
 
-        verify(oAuthService, times(1)).validateToken(any());
+        verify(authService, times(1)).validateToken(any());
 
         // restDocs
         resultActions.andDo(document("comment-delete-not-login",
@@ -310,8 +310,8 @@ class CommentControllerTest {
     @Test
     void delete_GuestUser_Success() throws Exception {
         // given
-        given(oAuthService.validateToken("token")).willReturn(true);
-        given(oAuthService.findRequestUserByToken("token")).willReturn(new LoginUser(1L, "kevin"));
+        given(authService.validateToken("token")).willReturn(true);
+        given(authService.findRequestUserByToken("token")).willReturn(new LoginUser(1L, "kevin"));
         Mockito.doNothing().when(commentService).deleteComment(any(CommentDeleteRequestDto.class));
 
         // when, then
@@ -319,8 +319,8 @@ class CommentControllerTest {
             .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
             .andExpect(status().isNoContent());
 
-        verify(oAuthService, times(1)).validateToken("token");
-        verify(oAuthService, times(1)).findRequestUserByToken("token");
+        verify(authService, times(1)).validateToken("token");
+        verify(authService, times(1)).findRequestUserByToken("token");
         verify(commentService, times(1))
             .deleteComment(any(CommentDeleteRequestDto.class));
 

--- a/backend/src/test/java/com/spring/blog/common/AcceptanceTest.java
+++ b/backend/src/test/java/com/spring/blog/common/AcceptanceTest.java
@@ -4,9 +4,12 @@ import com.spring.blog.authentication.presentation.dto.OAuthTokenResponse;
 import com.spring.blog.comment.presentation.dto.response.CommentResponse;
 import com.spring.blog.comment.presentation.dto.request.CommentWriteRequest;
 import com.spring.blog.configuration.InfrastructureTestConfiguration;
+import com.spring.blog.user.domain.User;
+import com.spring.blog.user.domain.repoistory.UserRepository;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
@@ -33,18 +36,26 @@ public class AcceptanceTest {
     private WebTestClient webTestClient;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.save(new User("kevin", "kevin@naver.com"));
+        userRepository.save(new User("other", "other@naver.com"));
+    }
 
     @AfterEach
     void tearDown() {
         databaseCleaner.execute();
-        ;
     }
 
     @DisplayName("로그인 요청 및 토큰 반환")
     protected String api_로그인_요청_및_토큰_반환(String userName) {
         return webTestClient.get()
-            .uri("/api/afterlogin?code={code}", userName)
+            .uri("/api/github/login?code={code}", userName)
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus()

--- a/backend/src/test/java/com/spring/blog/common/AcceptanceTest.java
+++ b/backend/src/test/java/com/spring/blog/common/AcceptanceTest.java
@@ -1,15 +1,14 @@
 package com.spring.blog.common;
 
 import com.spring.blog.authentication.presentation.dto.OAuthTokenResponse;
-import com.spring.blog.comment.presentation.dto.response.CommentResponse;
 import com.spring.blog.comment.presentation.dto.request.CommentWriteRequest;
+import com.spring.blog.comment.presentation.dto.response.CommentResponse;
 import com.spring.blog.configuration.InfrastructureTestConfiguration;
 import com.spring.blog.user.domain.User;
 import com.spring.blog.user.domain.repoistory.UserRepository;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
@@ -41,15 +40,14 @@ public class AcceptanceTest {
     @Autowired
     private DatabaseCleaner databaseCleaner;
 
-    @BeforeEach
-    void setUp() {
-        userRepository.save(new User("kevin", "kevin@naver.com"));
-        userRepository.save(new User("other", "other@naver.com"));
-    }
-
     @AfterEach
     void tearDown() {
         databaseCleaner.execute();
+    }
+
+    @DisplayName("회원 등록")
+    protected void api_회원_등록(String userName) {
+        userRepository.save(new User(userName, userName + "@naver.com"));
     }
 
     @DisplayName("로그인 요청 및 토큰 반환")

--- a/backend/src/test/java/com/spring/blog/common/mock/MockGithubOAuthClient.java
+++ b/backend/src/test/java/com/spring/blog/common/mock/MockGithubOAuthClient.java
@@ -2,8 +2,14 @@ package com.spring.blog.common.mock;
 
 import com.spring.blog.authentication.domain.OAuthClient;
 import com.spring.blog.authentication.domain.user.UserProfile;
+import java.util.Locale;
 
 public class MockGithubOAuthClient implements OAuthClient {
+
+    @Override
+    public boolean matches(String name) {
+        return name.toUpperCase(Locale.ROOT).equals("GITHUB");
+    }
 
     @Override
     public String getLoginUrl() {
@@ -17,6 +23,6 @@ public class MockGithubOAuthClient implements OAuthClient {
 
     @Override
     public UserProfile getUserProfile(String accessToken) {
-        return new UserProfile(accessToken, "image.url");
+        return new UserProfile(accessToken, accessToken + "@naver.com");
     }
 }

--- a/backend/src/test/java/com/spring/blog/configuration/InfrastructureTestConfiguration.java
+++ b/backend/src/test/java/com/spring/blog/configuration/InfrastructureTestConfiguration.java
@@ -1,14 +1,22 @@
 package com.spring.blog.configuration;
 
 import com.spring.blog.authentication.domain.OAuthClient;
+import com.spring.blog.authentication.domain.repository.OAuthClientRepository;
+import com.spring.blog.authentication.domain.repository.OAuthClientRepositoryImpl;
 import com.spring.blog.common.mock.MockFileStorage;
 import com.spring.blog.common.mock.MockGithubOAuthClient;
 import com.spring.blog.post.domain.FileStorage;
+import java.util.Arrays;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
 @TestConfiguration
 public class InfrastructureTestConfiguration {
+
+    @Bean
+    public OAuthClientRepository oAuthClientRepository() {
+        return new OAuthClientRepositoryImpl(Arrays.asList(oAuthClient()));
+    }
 
     @Bean
     public OAuthClient oAuthClient() {

--- a/backend/src/test/java/com/spring/blog/post/acceptance/PostAcceptanceTest.java
+++ b/backend/src/test/java/com/spring/blog/post/acceptance/PostAcceptanceTest.java
@@ -41,6 +41,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void write_LoginWithImage_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
 
         // when
@@ -84,6 +85,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void read_OnePost_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         api_테스트용_게시물_작성(token);
         String postId = api_게시물_작성_ID_회수("hi", "there", token);
@@ -117,6 +119,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void readList_OrderByDateDesc_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         for (int i = 0; i < 15; i++) {
             api_게시물_작성("title", "content" + i, token);
@@ -144,6 +147,8 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void readList_SearchByName_Success() {
         // given
+        api_회원_등록("kevin");
+        api_회원_등록("other");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         String token2 = api_로그인_요청_및_토큰_반환("other");
         api_게시물_작성("title1", "1", token);
@@ -171,6 +176,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void readList_SearchByTitle_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         api_게시물_작성("title1", "1", token);
         api_게시물_작성("title2", "2", token);
@@ -197,6 +203,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void readList_SearchByContent_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         api_게시물_작성("title1", "3kk", token);
         api_게시물_작성("title2", "333", token);
@@ -236,6 +243,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void delete_LoginUser_Failure() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
         String postId = api_게시물_작성_ID_회수("hi", "there", token);
 

--- a/backend/src/test/java/com/spring/blog/post/domain/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/spring/blog/post/domain/repository/PostRepositoryTest.java
@@ -25,8 +25,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
 
 @DisplayName("PostRepository 단위 테스트")
+@ActiveProfiles("test")
 @Import(JpaTestConfiguration.class)
 @DataJpaTest
 class PostRepositoryTest {

--- a/backend/src/test/java/com/spring/blog/user/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/spring/blog/user/acceptance/UserAcceptanceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.spring.blog.common.AcceptanceTest;
 import com.spring.blog.exception.dto.ApiErrorResponse;
+import com.spring.blog.user.presentation.dto.UserRegistrationRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 @DisplayName("User 인수 테스트")
@@ -32,6 +34,7 @@ class UserAcceptanceTest extends AcceptanceTest {
     @Test
     void withdraw_LoginUser_Success() {
         // given
+        api_회원_등록("kevin");
         String token = api_로그인_요청_및_토큰_반환("kevin");
 
         // when, then
@@ -41,5 +44,28 @@ class UserAcceptanceTest extends AcceptanceTest {
             .exchange()
             .expectStatus()
             .isNoContent();
+    }
+
+    @DisplayName("OAuth 기반으로 회원 가입을 진행한다.")
+    @Test
+    void registerByOauth_Success() {
+        // given
+        UserRegistrationRequest userRegistrationRequest = UserRegistrationRequest.builder()
+            .email("abc@naver.com")
+            .name("abc")
+            .build();
+
+        // when
+        webTestClient.post()
+            .uri("/api/users/oauth")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(userRegistrationRequest)
+            .exchange()
+            .expectStatus()
+            .isCreated();
+
+        // then
+        String token = api_로그인_요청_및_토큰_반환("abc");
+        assertThat(token).isNotNull();
     }
 }

--- a/backend/src/test/java/com/spring/blog/user/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/spring/blog/user/acceptance/UserAcceptanceTest.java
@@ -20,7 +20,7 @@ class UserAcceptanceTest extends AcceptanceTest {
     void withdraw_GuestUser_Failure() {
         // given, when, then
         webTestClient.delete()
-            .uri("/api/users/withdraw")
+            .uri("/api/users")
             .exchange()
             .expectStatus()
             .isUnauthorized()
@@ -36,7 +36,7 @@ class UserAcceptanceTest extends AcceptanceTest {
 
         // when, then
         webTestClient.delete()
-            .uri("/api/users/withdraw")
+            .uri("/api/users")
             .headers(httpHeaders -> httpHeaders.setBearerAuth(token))
             .exchange()
             .expectStatus()

--- a/backend/src/test/java/com/spring/blog/user/application/UserServiceTest.java
+++ b/backend/src/test/java/com/spring/blog/user/application/UserServiceTest.java
@@ -6,7 +6,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.spring.blog.exception.user.ActiveAccountExistingException;
+import com.spring.blog.exception.user.NameDuplicationException;
 import com.spring.blog.exception.user.UserNotFoundException;
+import com.spring.blog.user.application.dto.UserRegistrationRequestDto;
 import com.spring.blog.user.domain.User;
 import com.spring.blog.user.domain.repoistory.UserRepository;
 import java.util.Optional;
@@ -62,7 +65,7 @@ class UserServiceTest {
             @Test
             void it_deletes_user() {
                 // given
-                User user = new User(1L,"kevin", "image");
+                User user = new User(1L, "kevin", "image");
                 given(userRepository.findActiveUserById(1L)).willReturn(Optional.of(user));
 
                 // when
@@ -74,6 +77,91 @@ class UserServiceTest {
                     .isEqualTo(true);
 
                 verify(userRepository, times(1)).findActiveUserById(1L);
+            }
+        }
+    }
+
+    @DisplayName("registerByOauth 메서드는")
+    @Nested
+    class Describe_registerByOauth {
+
+        @DisplayName("회원가입하려는 이름이 이미 중복되는 경우(삭제된 회원 포함)")
+        @Nested
+        class Context_name_duplicated_including_deleted_users {
+
+            @DisplayName("NameDuplicationException이 발생한다.")
+            @Test
+            void it_throws_NameDuplicationException() {
+                // given
+                UserRegistrationRequestDto userRegistrationRequestDto =
+                    UserRegistrationRequestDto.builder()
+                        .name("abc")
+                        .email("abc@naver.com")
+                        .build();
+                User user = new User("abc", "kkk@naver.com");
+                given(userRepository.findByName("abc")).willReturn(Optional.of(user));
+
+                // when, then
+                assertThatCode(() -> userService.registerByOauth(userRegistrationRequestDto))
+                    .isInstanceOf(NameDuplicationException.class)
+                    .hasMessage("중복된 이름입니다.")
+                    .hasFieldOrPropertyWithValue("errorCode", "U0003")
+                    .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.BAD_REQUEST);
+
+                verify(userRepository, times(1)).findByName("abc");
+            }
+        }
+
+        @DisplayName("이름은 중복이 아니지만 동일 이메일로 활성화된 유저 계정이 존재하는 경우")
+        @Nested
+        class Context_name_unique_but_same_email_account_alive {
+
+            @DisplayName("NameDuplicationException이 발생한다.")
+            @Test
+            void it_throws_NameDuplicationException() {
+                // given
+                UserRegistrationRequestDto userRegistrationRequestDto =
+                    UserRegistrationRequestDto.builder()
+                        .name("abc")
+                        .email("abc@naver.com")
+                        .build();
+                User user = new User("kkk", "kkk@naver.com");
+                given(userRepository.findByName("abc")).willReturn(Optional.empty());
+                given(userRepository.findActiveUserByEmail("abc@naver.com"))
+                    .willReturn(Optional.of(user));
+
+                // when, then
+                assertThatCode(() -> userService.registerByOauth(userRegistrationRequestDto))
+                    .isInstanceOf(ActiveAccountExistingException.class)
+                    .hasMessage("동일한 이메일로 등록된 회원 계정이 존재합니다.")
+                    .hasFieldOrPropertyWithValue("errorCode", "U0004")
+                    .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.BAD_REQUEST);
+
+                verify(userRepository, times(1)).findByName("abc");
+                verify(userRepository, times(1)).findActiveUserByEmail("abc@naver.com");
+            }
+        }
+
+        @DisplayName("이메일과 이름 모두 중복이 없는 경우")
+        @Nested
+        class Context_none_duplication {
+
+            @DisplayName("회원을 생성한다.")
+            @Test
+            void it_throws_NameDuplicationException() {
+                // given
+                UserRegistrationRequestDto userRegistrationRequestDto =
+                    UserRegistrationRequestDto.builder()
+                        .name("abc")
+                        .email("abc@naver.com")
+                        .build();
+                given(userRepository.findByName("abc")).willReturn(Optional.empty());
+                given(userRepository.findActiveUserByEmail("abc@naver.com"))
+                    .willReturn(Optional.empty());
+
+                // when, then
+                assertThatCode(() -> userService.registerByOauth(userRegistrationRequestDto))
+                    .doesNotThrowAnyException();
             }
         }
     }

--- a/backend/src/test/java/com/spring/blog/user/domain/UserTest.java
+++ b/backend/src/test/java/com/spring/blog/user/domain/UserTest.java
@@ -1,9 +1,14 @@
 package com.spring.blog.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
+import com.spring.blog.exception.user.InvalidUserNameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpStatus;
 
 @DisplayName("User 엔티티 단위 테스트")
 class UserTest {
@@ -12,7 +17,7 @@ class UserTest {
     @Test
     void withdraw_isDeleted_True() {
         // given
-        User user = new User("kevin", "image");
+        User user = new User("aaaaaaaaaa", "image");
 
         // when
         user.withdraw();
@@ -21,5 +26,17 @@ class UserTest {
         assertThat(user)
             .extracting("isDeleted")
             .isEqualTo(true);
+    }
+
+    @DisplayName("이름은 2~10자만 가능하다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"a", "aaaaaaaaaaa"})
+    void newUser_invalidLength_Exception(String name) {
+        // given, when, then
+        assertThatCode(() -> new User(name, "abc@naver.com"))
+            .isInstanceOf(InvalidUserNameException.class)
+            .hasFieldOrPropertyWithValue("errorCode", "U0002")
+            .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.NOT_FOUND)
+            .hasMessage("유저 이름은 2~10자입니다.");
     }
 }

--- a/backend/src/test/java/com/spring/blog/user/domain/UserTest.java
+++ b/backend/src/test/java/com/spring/blog/user/domain/UserTest.java
@@ -1,7 +1,6 @@
 package com.spring.blog.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,6 @@ class UserTest {
     void withdraw_isDeleted_True() {
         // given
         User user = new User("kevin", "image");
-        user.activate();
 
         // when
         user.withdraw();
@@ -23,21 +21,5 @@ class UserTest {
         assertThat(user)
             .extracting("isDeleted")
             .isEqualTo(true);
-    }
-
-    @DisplayName("활성화시 삭제 상태 정보가 False로 변경된다.")
-    @Test
-    void activate_isDeleted_False() {
-        // given
-        User user = new User("kevin", "image");
-        user.withdraw();
-
-        // when
-        user.activate();
-
-        // then
-        assertThat(user)
-            .extracting("isDeleted")
-            .isEqualTo(false);
     }
 }

--- a/backend/src/test/java/com/spring/blog/user/integration/UserServiceIntegration.java
+++ b/backend/src/test/java/com/spring/blog/user/integration/UserServiceIntegration.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.spring.blog.common.IntegrationTest;
 import com.spring.blog.exception.user.UserNotFoundException;
 import com.spring.blog.user.application.UserService;
+import com.spring.blog.user.application.dto.UserRegistrationRequestDto;
 import com.spring.blog.user.domain.User;
 import com.spring.blog.user.domain.repoistory.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -36,5 +37,23 @@ class UserServiceIntegration extends IntegrationTest {
         assertThat(findUser)
             .extracting("isDeleted")
             .isEqualTo(true);
+    }
+
+    @DisplayName("User를 OAuth로 등록한다.")
+    @Test
+    void registerByOauth_ValidRequest_Success() {
+        // given
+        UserRegistrationRequestDto userRegistrationRequestDto =
+            UserRegistrationRequestDto.builder()
+                .name("hha")
+                .email("ala@naber.com")
+                .build();
+
+        // when
+        userService.registerByOauth(userRegistrationRequestDto);
+
+        // then
+        assertThat(userRepository.findByName("hha"))
+            .isNotEmpty();
     }
 }

--- a/backend/src/test/java/com/spring/blog/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/com/spring/blog/user/presentation/UserControllerTest.java
@@ -4,20 +4,25 @@ import static com.spring.blog.common.ApiDocumentUtils.getDocumentRequest;
 import static com.spring.blog.common.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spring.blog.authentication.application.AuthService;
 import com.spring.blog.authentication.domain.user.LoginUser;
 import com.spring.blog.user.application.UserService;
+import com.spring.blog.user.application.dto.UserRegistrationRequestDto;
+import com.spring.blog.user.presentation.dto.UserRegistrationRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -26,6 +31,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -36,6 +42,9 @@ class UserControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockBean
     private UserService userService;
@@ -87,6 +96,29 @@ class UserControllerTest {
             getDocumentRequest(),
             getDocumentResponse(),
             requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer token")))
+        );
+    }
+
+    @DisplayName("OAuth 기반으로 회원가입할 수 있다.")
+    @Test
+    void registerByOauth_Success() throws Exception {
+        // given
+        UserRegistrationRequest userRegistrationRequest = UserRegistrationRequest.builder()
+            .name("abc")
+            .email("abc@naver.com")
+            .build();
+        doNothing().when(userService).registerByOauth(any(UserRegistrationRequestDto.class));
+
+        // when, then
+        ResultActions resultActions = mockMvc.perform(post("/api/users/oauth")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(userRegistrationRequest)))
+            .andExpect(status().isCreated());
+
+        // restDocs
+        resultActions.andDo(document("register-oauth",
+            getDocumentRequest(),
+            getDocumentResponse())
         );
     }
 }


### PR DESCRIPTION
## API 변경

* 확장성을 위해 github이 아닌 다양한 oauth로 회원가입 / 로그인이 가능하도록 auth 관련 api url 수정
* OAuthClientRepository 생성 및 기관에 맞는 client 반환 기능 구현
* user 삭제 api 주소 수정
* oauth기반 로그인-회원가입과 oauth 미기반 로그인-회원가입 가능하도록 api 분리
* user 정보 가져와서 email 기반으로 oauth 유저 존재하는지 확인

## 그 외

* user 엔티티 컬럼 profileimage 삭제 및 email 추가
* 회원가입 front-end 구현

Close #84 